### PR TITLE
Hero Mode view + Refactoring.

### DIFF
--- a/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
+++ b/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
@@ -343,6 +343,7 @@ public class EditorsChoiceActivityController : ControllerBase
             response.Add("transitionEffect", _config.TransitionEffect);
             response.Add("showPlayButton", _config.ShowPlayButton);
             response.Add("hideOnTvLayout", _config.HideOnTvLayout);
+            response.Add("heroBackdropPosition", _config.HeroBackdropPosition);
             if (!string.IsNullOrEmpty(_config.Heading)) response.Add("heading", _config.Heading);
 
             // If ShowPlayButton is true and a PlayButtonText is set, include this in the response to allow custom play button text

--- a/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
+++ b/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
@@ -340,8 +340,15 @@ public class EditorsChoiceActivityController : ControllerBase
             response.Add("reduceImageSizes", _config.ReduceImageSize);
             response.Add("bannerHeight", _config.BannerHeight);
             response.Add("useHeroLayout", _config.UseHeroLayout);
+            response.Add("transitionEffect", _config.TransitionEffect);
+            response.Add("showPlayButton", _config.ShowPlayButton);
             response.Add("hideOnTvLayout", _config.HideOnTvLayout);
             if (!string.IsNullOrEmpty(_config.Heading)) response.Add("heading", _config.Heading);
+
+            // If ShowPlayButton is true and a PlayButtonText is set, include this in the response to allow custom play button text
+            if (_config.ShowPlayButton && !string.IsNullOrEmpty(_config.PlayButtonText))
+            {                response.Add("playButtonText", _config.PlayButtonText);
+            }
 
             return Ok(response);
 

--- a/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
+++ b/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
@@ -339,8 +339,9 @@ public class EditorsChoiceActivityController : ControllerBase
             response.Add("autoplayInterval", _config.AutoplayInterval * 1000);
             response.Add("reduceImageSizes", _config.ReduceImageSize);
             response.Add("bannerHeight", _config.BannerHeight);
+            response.Add("useHeroLayout", _config.UseHeroLayout);
             response.Add("hideOnTvLayout", _config.HideOnTvLayout);
-            if (_config.Heading != null) response.Add("heading", _config.Heading);
+            if (!string.IsNullOrEmpty(_config.Heading)) response.Add("heading", _config.Heading);
 
             return Ok(response);
 

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -195,15 +195,26 @@ const container = `
   }
 
   .editorsChoiceHeroMode .editorsChoiceItemBanner { background-position-y: 15% !important; }
-  .editorsChoiceHeroMode .editorsChoiceItemBanner > div { padding-top: 120px; }
   .editorsChoiceHeroMode .editorsChoiceScrollButtonsContainer .emby-scrollbuttons { padding-top: 120px; }
+
+  .editorsChoiceHeroMode  .editorsChoiceBackdropCenter {
+      background-position: center;
+  }
+
+  .editorsChoiceHeroMode .editorsChoiceBackdropTop {
+      background-position: top;
+  }
+
+  .editorsChoiceHeroMode .editorsChoiceBackdropBottom {
+      background-position: bottom;
+  }
 
   .editorsChoiceHeroMode .editorsChoiceItemBanner .editorsChoiceBackdrop {
     position: absolute;
     inset: 0;
     z-index: 0;
     background-size: cover;
-    background-position: center 52%;
+
     background-repeat: no-repeat;
     mask-image: linear-gradient(
       to bottom,
@@ -364,12 +375,15 @@ function renderHeroSlide(item, data, baseUrl) {
 
     const backdropSize = buildBannerSizeParam(data.reduceImageSizes);
     const backdropUrl = `../Items/${item.id}/Images/Backdrop/0${backdropSize}`;
+    const extraClass = data.heroBackdropPosition === "center" ? "editorsChoiceBackdropCenter" :
+        data.heroBackdropPosition === "top" ? "editorsChoiceBackdropTop" :
+        data.heroBackdropPosition === "bottom" ? "editorsChoiceBackdropBottom" : "";
 
     return `
   <a href="${baseUrl}#/details?id=${item.id}"
      onclick="Emby.Page.showItem('${item.id}'); return false;"
      class="editorsChoiceItemBanner splide__slide">
-    <div class="editorsChoiceBackdrop" style="background-image:url('${backdropUrl}');"></div>
+    <div class="editorsChoiceBackdrop ${extraClass}" style="background-image:url('${backdropUrl}');"></div>
     <div class="editorsChoiceContent">
       ${logoOrTitle}
       ${rating}

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -184,7 +184,7 @@ const container = `
 
   /* ===== Hero mode ===== */
   .editorsChoiceHeroMode .editorsChoiceContainer { padding: 0 !important; }
-  .editorsChoiceHeroMode #indexPage { transform: translateY(-120px); }
+  .editorsChoiceHeroMode #homeTab { transform: translateY(-120px); }
 
   .editorsChoiceHeroMode .splide.cardScalable {
     border-radius: unset !important;

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -253,7 +253,7 @@ const container = `
     position: relative;
     z-index: 2;
     height: 100%;
-    padding: 30px;
+    padding: 30px max(env(safe-area-inset-right), 3.3%);
     box-sizing: border-box;
     display: flex;
     flex-direction: column;

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -157,7 +157,7 @@ const container = `
   }
 
   .editorsChoiceItemButton {
-    width: auto !important;
+    width: fit-content !important;
     display: inline-block !important;
     position: absolute;
     margin: 0 !important;
@@ -212,6 +212,14 @@ const container = `
       rgba(0,0,0,0.4) 70%,
       rgba(0,0,0,0) 100%
     );
+  }
+
+  .editorsChoiceHeroMode .editorsChoiceItemButton {
+    width: fit-content !important;
+    display: inline-flex !important;
+    position: relative;
+    margin: 0 !important;
+    bottom: unset !important;
   }
 
   .editorsChoiceHeroMode .editorsChoiceItemBanner .editorsChoiceBackdrop::after {
@@ -341,6 +349,19 @@ function renderHeroSlide(item, data, baseUrl) {
     const logoOrTitle = buildLogoOrTitle(item, data.reduceImageSizes);
     const overview = buildOverview(item);
 
+    let button = "";
+
+    if(data.showPlayButton) {
+        let buttonString = getLocalizedString("watchButton");
+        // Check if Custom Text is set.
+        if (data.playButtonText) {
+            buttonString = data.playButtonText;
+        }
+        button = `<button is="emby-button" class="editorsChoiceItemButton raised button-submit emby-button">
+                    <span>${buttonString}</span>
+                  </button>`;
+    }
+
     const backdropSize = buildBannerSizeParam(data.reduceImageSizes);
     const backdropUrl = `../Items/${item.id}/Images/Backdrop/0${backdropSize}`;
 
@@ -353,6 +374,7 @@ function renderHeroSlide(item, data, baseUrl) {
       ${logoOrTitle}
       ${rating}
       ${overview}
+      ${button}
     </div>
   </a>`;
 }
@@ -363,22 +385,29 @@ function renderNormalSlide(item, data, baseUrl) {
     const overview = buildOverview(item);
 
     const bannerSize = buildBannerSizeParam(data.reduceImageSizes);
-    const button = `<button is="emby-button" class="editorsChoiceItemButton raised button-submit block emby-button">
-                    <span>${getLocalizedString("watchButton")}</span>
+    let button = "";
+    if(data.showPlayButton) {
+        let buttonString = getLocalizedString("watchButton");
+        // Check if Custom Text is set.
+        if (data.playButtonText) {
+            buttonString = data.playButtonText;
+        }
+        button = `<button is="emby-button" class="editorsChoiceItemButton raised button-submit emby-button">
+                    <span>${buttonString}</span>
                   </button>`;
+    }
 
-    return `
-  <a href="${baseUrl}#/details?id=${item.id}"
-     onclick="Emby.Page.showItem('${item.id}'); return false;"
-     class="editorsChoiceItemBanner splide__slide"
-     style="background-image:url('../Items/${item.id}/Images/Backdrop/0${bannerSize}');">
-    <div>
-      ${logoOrTitle}
-      ${rating}
-      ${overview}
-      ${button}
-    </div>
-  </a>`;
+    return `<a href="${baseUrl}#/details?id=${item.id}"
+                 onclick="Emby.Page.showItem('${item.id}'); return false;"
+                 class="editorsChoiceItemBanner splide__slide"
+                 style="background-image:url('../Items/${item.id}/Images/Backdrop/0${bannerSize}');">
+                <div>
+                  ${logoOrTitle}
+                  ${rating}
+                  ${overview}
+                  ${button}
+                </div>
+              </a>`;
 }
 
 /* ===== Main setup ===== */
@@ -444,9 +473,11 @@ async function setup() {
                 const playPauseBtn = document.getElementById("editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
 
+
                 new Splide(`#${containerId} .splide`, {
-                    type: "loop",
+                    type: data.transitionEffect ?? "slide",
                     autoplay: !!data.autoplay,
+                    rewind: true,
                     interval: data.autoplayInterval,
                     pagination: false,
                     keyboard: true,

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -1,405 +1,494 @@
-const container = `<div class="verticalSection section-1 editorsChoiceContainer">
-    <div class="splide cardScalable">
-        <div class="editorsChoiceScrollButtonsContainer">
-            <div class="emby-scrollbuttons splide__arrows">
-                <button type="button" is="paper-icon-button-light" data-ripple="false" data-direction="left" title="Previous" class="emby-scrollbuttons-button paper-icon-button-light splide__arrow splide__arrow--prev">
-                    <span class="material-icons chevron_left" aria-hidden="true"></span>
-                </button>
-                <button type="button" is="paper-icon-button-light" data-ripple="false" data-direction="right" title="Next" class="emby-scrollbuttons-button paper-icon-button-light splide__arrow splide__arrow--next">
-                    <span class="material-icons chevron_right" aria-hidden="true"></span>
-                </button>
-            </div>
-        </div>
-        <div class="editorsChoicePlayPauseContainer">
-            <button class="splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button">
-                <span class="splide__toggle__play material-icons play_arrow" aria-hidden="true"></span>
-                <span class="splide__toggle__pause material-icons pause" aria-hidden="true"></span>
-            </button>
-        </div>
-        <div class="splide__track">
-            <div is="emby-itemscontainer" class="editorsChoiceItemsContainer splide__list animatedScrollX">
-            </div>
-        </div>
+const container = `
+<div class="verticalSection section-1 editorsChoiceContainer">
+  <div class="splide cardScalable">
+    <div class="editorsChoiceScrollButtonsContainer">
+      <div class="emby-scrollbuttons splide__arrows">
+        <button type="button" is="paper-icon-button-light" data-ripple="false" data-direction="left" title="Previous"
+          class="emby-scrollbuttons-button paper-icon-button-light splide__arrow splide__arrow--prev">
+          <span class="material-icons chevron_left" aria-hidden="true"></span>
+        </button>
+
+        <button class="splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button" id="editorsChoicePlayPause">
+          <span class="splide__toggle__play material-icons play_arrow" aria-hidden="true"></span>
+          <span class="splide__toggle__pause material-icons pause" aria-hidden="true"></span>
+        </button>
+
+        <button type="button" is="paper-icon-button-light" data-ripple="false" data-direction="right" title="Next"
+          class="emby-scrollbuttons-button paper-icon-button-light splide__arrow splide__arrow--next">
+          <span class="material-icons chevron_right" aria-hidden="true"></span>
+        </button>
+      </div>
     </div>
+
+    <div class="splide__track">
+      <div is="emby-itemscontainer" class="editorsChoiceItemsContainer splide__list animatedScrollX"></div>
+    </div>
+  </div>
 </div>
 
 <style>
-    .homeSectionsContainer.editorsChoiceAdded {
-        padding-top: 0 !important;
-    }
+  /* ===== Layout / spacing ===== */
+  .homeSectionsContainer.editorsChoiceAdded { padding-top: 0 !important; }
 
-    .homeSectionsContainer.editorsChoiceAdded .editorsChoiceContainer {
-        padding-left: 3.3%;
-        padding-left: max(env(safe-area-inset-left), 3.3%);
-        padding-right: 3.3%;
-        padding-right: max(env(safe-area-inset-right), 3.3%);
-        margin-bottom: 1.8em;
-    }
+  .homeSectionsContainer.editorsChoiceAdded .editorsChoiceContainer {
+    padding-left: max(env(safe-area-inset-left), 3.3%);
+    padding-right: max(env(safe-area-inset-right), 3.3%);
+    margin-bottom: 1.8em;
+  }
 
-    .editorsChoiceItemsContainer {
-        column-gap: normal !important;
-    }
+  .editorsChoiceContainer .sectionTitle-cards { padding-bottom: 0.35em; }
+  .editorsChoiceItemsContainer { column-gap: normal !important; }
 
-    .editorsChoiceScrollButtonsContainer, .editorsChoicePlayPauseContainer {
-        position: absolute;
-        z-index: 99;
-        right: 0.15em;
-        mix-blend-mode: difference;
-    }
+  @media screen and (max-width: 1600px) {
+    .homeSectionsContainer.editorsChoiceAdded { margin-top: 30px; }
+  }
 
-    .editorsChoiceScrollButtonsContainer {
-        width: 7em;
-    }
+  /* ===== Controls ===== */
+  .editorsChoiceScrollButtonsContainer,
+  .editorsChoicePlayPauseContainer {
+    position: absolute;
+    z-index: 99;
+    right: 0.15em;
+    mix-blend-mode: difference;
+  }
 
-    .editorsChoicePlayPauseContainer {
-        width: 4em;
-    }
+  .editorsChoiceScrollButtonsContainer { width: 7em; }
+  .editorsChoicePlayPauseContainer { width: 4em; display: none; bottom: 0.83em; }
 
-    .editorsChoiceScrollButtonsContainer > .splide__arrows, .editorsChoicePlayPauseContainer > .splide__toggle {
-        float: right;
-    }
+  .editorsChoiceScrollButtonsContainer > .splide__arrows,
+  .editorsChoicePlayPauseContainer > .splide__toggle {
+    float: right;
+  }
 
-    @media screen and (max-width: 500px) {
-        .editorsChoiceScrollButtonsContainer, .editorsChoicePlayPauseContainer {
-            display: none;
-        }
-    }
+  @media screen and (max-width: 500px) {
+    .editorsChoiceScrollButtonsContainer,
+    .editorsChoicePlayPauseContainer { display: none; }
+  }
 
-    .splide__track {
-        border-radius: 0.2em;
-    }
+  .splide__track { border-radius: 0.2em; }
 
-    .splide__arrow, .splide__toggle {
-        position: relative;
-        display: inline-block;
-        opacity: 1;
-        top: auto;
-        transform: none;
-        width: auto;
-        height: auto;
-        padding: .556em;
-        background: transparent;
-    }
+  .splide__arrow,
+  .splide__toggle {
+    position: relative;
+    display: inline-block;
+    opacity: 1;
+    top: auto;
+    transform: none;
+    width: auto;
+    height: auto;
+    padding: .556em;
+    background: transparent;
+  }
 
-    .splide__arrow--next {
-        right: auto;
-    }
+  .splide__arrow--next { right: auto; }
+  .splide__arrow--prev { left: auto; }
 
-    .splide__arrow--prev {
-        left: auto;
-    }
+  .splide__toggle.is-active .splide__toggle__play,
+  .emby-scrollbuttons-button > .splide__toggle__pause {
+    display: none;
+  }
 
-    .editorsChoicePlayPauseContainer {
-        display: none;
-        bottom: 0.83em;
-    }
+  /* ===== Banner ===== */
+  .editorsChoiceItemBanner {
+    width: 100%;
+    height: 360px;
+    flex: none;
+    background-size: cover;
+    background-position-x: center;
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.8);
+    text-decoration: none;
+    background-position-y: 52%;
+  }
 
-    .splide__toggle.is-active .splide__toggle__play, .emby-scrollbuttons-button>.splide__toggle__pause {
-        display: none;
-    }
+  .editorsChoiceItemBanner:nth-child(odd) { background-position-y: 48%; }
 
-    .editorsChoiceItemBanner {
-        width: 100%;
-        height: 360px;
-        flex: none;
-        background-size: cover;
-        background-position-x: center;
-        cursor: pointer;
-        color: #ddd;
-        color: rgba(255, 255, 255, 0.8);
-        text-decoration: none;
-    }
+  @keyframes banner {
+    0% { background-position-y: 52%; }
+    100% { background-position-y: 48%; }
+  }
 
-    @keyframes banner {
-        0% {background-position-y: 52%;}
-        100% {background-position-y: 48%;}
-    }
+  .editorsChoiceItemBanner.is-visible {
+    animation: banner 10s infinite alternate both;
+  }
 
-    .editorsChoiceItemBanner {
-        background-position-y: 52%;
-    }
+  .editorsChoiceItemBanner:nth-child(odd).is-visible {
+    animation-direction: alternate-reverse;
+  }
 
-    .editorsChoiceItemBanner:nth-child(odd) {
-        background-position-y: 48%;
-    }
+  .editorsChoiceItemBanner > div {
+    width: 100%;
+    height: 100%;
+    padding: 30px;
+    box-sizing: border-box;
+    background: linear-gradient(90deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0) 60%, rgba(0,0,0,0) 100%);
+  }
 
-    .editorsChoiceItemBanner.is-visible {
-        animation-name: banner;
-        animation-duration: 10s;
-        animation-fill-mode: both;
-        animation-iteration-count: infinite;
-        animation-direction: alternate;
-    }
+  /* ===== Content ===== */
+  .editorsChoiceItemLogo {
+    display: block;
+    max-width: 300px;
+    max-height: calc(50% - 45px);
+  }
 
-    .editorsChoiceItemBanner:nth-child(odd).is-visible {
-        animation-direction: alternate-reverse;
-    }
+  .editorsChoiceItemTitle {
+    max-width: 100%;
+    margin: 0 60px 0 0;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
-    .editorsChoiceItemBanner > div {
-        width: 100%;
-        height: 100%;
-        padding: 30px;
-        box-sizing: border-box;
-        background: linear-gradient(90deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 60%, rgba(0, 0, 0, 0) 100%);
-    }
+  .editorsChoiceItemOverview {
+    white-space: normal;
+    width: 650px;
+    min-width: 40%;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    overflow: hidden;
+  }
 
+  .layout-tv .editorsChoiceItemOverview {
+    min-width: 55%;
+    -webkit-line-clamp: 2;
+  }
+
+  .editorsChoiceItemButton {
+    width: auto !important;
+    display: inline-block !important;
+    position: absolute;
+    margin: 0 !important;
+    bottom: 30px;
+  }
+
+  .editorsChoiceItemRating { display: block !important; margin-top: 1em; }
+
+  .starIcon {
+    color: #f2b01e;
+    font-size: 1.4em;
+    margin-right: 0.125em;
+    vertical-align: bottom;
+  }
+
+  @media screen and (max-width: 500px) {
     .editorsChoiceItemLogo {
-        display: block;
-        max-width: 300px;
-        max-height: calc(50% - 45px);
+      max-width: 100%;
+      max-height: 100px;
+      height: auto;
+      filter: drop-shadow(3px 3px 15px black);
     }
+  }
 
-    .editorsChoiceItemTitle {
-        max-width: 100%;
-        margin: 0 60px 0 0;
-        font-weight: 600;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
+  /* ===== Hero mode ===== */
+  .editorsChoiceHeroMode .editorsChoiceContainer { padding: 0 !important; }
+  .editorsChoiceHeroMode #indexPage { transform: translateY(-120px); }
 
-    .editorsChoiceItemOverview {
-        white-space: normal;
-        width: 650px;
-        min-width: 40%;
-        max-width: 100%;
-        text-overflow: ellipsis;
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 4;
-        overflow: hidden;
-    }
+  .editorsChoiceHeroMode .splide.cardScalable {
+    border-radius: unset !important;
+    border: 0 !important;
+    background: transparent;
+    box-shadow: none !important;
+    margin-bottom: -120px;
+  }
 
-    .layout-tv .editorsChoiceItemOverview {
-        min-width: 55%;
-        -webkit-line-clamp: 2;
-    }
+  .editorsChoiceHeroMode .editorsChoiceItemBanner { background-position-y: 15% !important; }
+  .editorsChoiceHeroMode .editorsChoiceItemBanner > div { padding-top: 120px; }
+  .editorsChoiceHeroMode .editorsChoiceScrollButtonsContainer .emby-scrollbuttons { padding-top: 120px; }
 
-    .editorsChoiceItemButton {
-        width: auto !important;
-        display: inline-block !important;
-        position: absolute;
-        margin: 0 !important;
-        bottom: 30px;
-    }
+  .editorsChoiceHeroMode .editorsChoiceItemBanner .editorsChoiceBackdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    background-size: cover;
+    background-position: center 52%;
+    background-repeat: no-repeat;
+    mask-image: linear-gradient(
+      to bottom,
+      rgba(0,0,0,1) 40%,
+      rgba(0,0,0,0.9) 55%,
+      rgba(0,0,0,0.4) 70%,
+      rgba(0,0,0,0) 100%
+    );
+  }
 
-    .editorsChoiceItemRating {
-        display: block !important;
-        margin-top: 1em;
-    }
+  .editorsChoiceHeroMode .editorsChoiceItemBanner .editorsChoiceBackdrop::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background: linear-gradient(
+      135deg,
+      rgba(0,0,0,0.95) 0%,
+      rgba(0,0,0,0.85) 15%,
+      rgba(0,0,0,0.55) 30%,
+      rgba(0,0,0,0.25) 50%,
+      rgba(0,0,0,0.08) 65%,
+      rgba(0,0,0,0) 80%
+    );
+  }
 
-    .starIcon {
-        color: #f2b01e;
-        font-size: 1.4em;
-        margin-right: 0.125em;
-        vertical-align: bottom;
-    }
-
-    editorsChoiceContainer .sectionTitle-cards {
-        padding-bottom: 0.35em;
-    }
-
-    @media screen and (max-width: 500px) {
-        .editorsChoiceItemLogo {
-            max-width: 100%;
-            max-height: 100px;
-            height: auto;
-            filter: drop-shadow(3px 3px 15px black);
-        }
-    }
-
-    @media screen and (max-width: 1600px) {
-        .homeSectionsContainer.editorsChoiceAdded {
-            margin-top: 30px;
-        }
-    }
+  .editorsChoiceHeroMode .editorsChoiceItemBanner .editorsChoiceContent {
+    position: relative;
+    z-index: 2;
+    height: 100%;
+    padding: 30px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    background: none !important;
+  }
 </style>
-
 `;
 
-// https://dev.to/codebubb/how-to-shuffle-an-array-in-javascript-2ikj#:~:text=the%20fisher-yates%20algorith
-function shuffle(old_array) {
-    var array = old_array
+const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
+
+/* ===== Utils ===== */
+function shuffle(input) {
+    const array = input.slice(); // don't mutate original
     for (let i = array.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
-        const temp = array[i];
-        array[i] = array[j];
-        array[j] = temp;
+        [array[i], array[j]] = [array[j], array[i]];
     }
     return array;
 }
 
-const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
-
-// Function to get localized string based on user's language
 function getLocalizedString(key) {
     const localization = {
-        'watchButton': {
-            'en': 'Watch',
-            'fr': 'Regarder',
-            'es': 'Ver',
-            'de': 'Ansehen',
-            'it': 'Guarda',
-            'pt': 'Assistir',
-            'zh': '观看',
-            'ja': '見る',
-            'ru': 'Смотреть'
-        }
+        watchButton: {
+            en: "Watch",
+            fr: "Regarder",
+            es: "Ver",
+            de: "Ansehen",
+            it: "Guarda",
+            pt: "Assistir",
+            zh: "观看",
+            ja: "見る",
+            ru: "Смотреть",
+        },
     };
 
-    const userLanguage = navigator.language.slice(0, 2); // Retrieve the first two characters of the user's language
-    return (localization[key] && localization[key][userLanguage]) ||
-       (localization[key] && localization[key]['en']); // Fallback to English if the user's language is not available
+    const lang = (navigator.language || "en").slice(0, 2);
+    return (localization[key] && (localization[key][lang] || localization[key].en)) || "";
 }
 
-// Setup slider
-function setup() {
-    console.log("Attempting creation of editors choice slider.");
-    $('.homeSectionsContainer').each((index, elem) => {
-        if (!$(elem).hasClass('editorsChoiceAdded')) {
-            console.log("Fetching favourites data from API...");
-            ApiClient.fetch({url: ApiClient.getUrl('/EditorsChoice/favourites'), type: 'GET'}).then(function(response) {
-                response.json().then(function(data) {
-                    // If configured to hide on TV layout, and the page has layout-tv, skip rendering
-                    if (data.hideOnTvLayout && document.documentElement.classList.contains('layout-tv')) {
-                        console.log('Editors Choice: hidden on TV layout by configuration.');
-                        return;
-                    }
-                    var favourites = shuffle(data.favourites);
+function getBaseUrl() {
+    let baseUrl = Emby.Page.baseUrl() + "/";
+    if (window.location.href.includes("/index.html")) baseUrl += "index.html";
+    return baseUrl;
+}
 
-                    var containerElem = $(container);
-                    var containerId = 'editorsChoice-' + Date.now();
-                    containerElem.first().attr('id', containerId); // add unique id to container element to handle duplicate indexPages
-                    $(elem).prepend(containerElem);
+function buildRating(item) {
+    const rating = typeof item.community_rating === "number" ? Number(item.community_rating.toFixed(1)) : 0;
+    if (rating === 0) return "";
+    return `<div class="editorsChoiceItemRating starRatingContainer">
+            <span class="material-icons starIcon star"></span>${rating}
+          </div>`;
+}
 
-                    var focusResolved = false;
-                    $('.layout-tv #' + containerId + ' .emby-scrollbuttons button').on('focus', function () {
-                        if (!focusResolved) {
-                            $('[is="emby-tabs"] .emby-button').first().trigger('focus');
-                            focusResolved = true;
-                        }
-                    });
+function buildLogoOrTitle(item, reduceImageSizes) {
+    if (!item.hasLogo) return `<h1 class="editorsChoiceItemTitle">${item.name}</h1>`;
+    const logoSize = reduceImageSizes ? "?width=300" : "";
+    return `<img class="editorsChoiceItemLogo" src="../Items/${item.id}/Images/Logo/0${logoSize}" alt="${item.name}"/>`;
+}
 
-                    // Add heading if exists
-                    if ('heading' in data) {
-                        $(containerElem).prepend(`<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
-                    }
+function buildOverview(item) {
+    const overview = (item && typeof item.overview === "string") ? item.overview : "";
+    return overview ? `<p class="editorsChoiceItemOverview">${overview}</p>` : "";
+}
 
-                    favourites.forEach((favourite, i) => {
+function buildBannerSizeParam(reduceImageSizes) {
+    if (!reduceImageSizes) return "";
+    const w = Math.max(window.screen.width, window.screen.height);
+    return `?width=${w}`;
+}
 
-                        // Process star rating
-                        var communityRating = 0;
+function ensureSplideLoaded() {
+    return new Promise((resolve, reject) => {
+        if (window.Splide) return resolve();
 
-                        if ('community_rating' in favourite) {
-                            communityRating = favourite.community_rating.toFixed(1);
-                        }
+        const existing = document.querySelector('script[data-editorschoice-splide="1"]');
+        if (existing) {
+            existing.addEventListener("load", resolve, { once: true });
+            existing.addEventListener("error", reject, { once: true });
+            return;
+        }
 
-                        var editorsChoiceItemRating = `<div class='editorsChoiceItemRating starRatingContainer'><span class='material-icons starIcon star'></span>${communityRating}</div>`;
+        const s = document.createElement("script");
+        s.type = "text/javascript";
+        s.src = "https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/js/splide.min.js";
+        s.setAttribute("data-editorschoice-splide", "1");
+        s.addEventListener("load", resolve, { once: true });
+        s.addEventListener("error", reject, { once: true });
+        document.head.appendChild(s);
 
-                        // skip rating if it is 0 - a perfect zero means the metadata provider has no score so is misrepresentative
-                        if (communityRating == 0) {
-                            editorsChoiceItemRating = "";
-                        }
-
-                        // Process logo
-                        var logoImageSize = "";
-                        if (data.reduceImageSizes) {
-                            logoImageSize = "?width=300";
-                        }
-                        var editorsChoiceItemLogo = `<img class='editorsChoiceItemLogo' src='../Items/${favourite.id}/Images/Logo/0${logoImageSize}' alt='${favourite.name}'/>`;
-                        if (!favourite.hasLogo) editorsChoiceItemLogo = `<h1 class="editorsChoiceItemTitle">${favourite.name}</h1>`;
-
-                        // Process item description
-                        if (!('overview' in favourite)) {
-                            favourite.overview = "";
-                        }
-
-                        var editorsChoiceItemOverview = `<p class='editorsChoiceItemOverview'>${favourite.overview}</p>`;
-
-                        if (favourite.overview == "") {
-                            editorsChoiceItemOverview = "";
-                        }
-
-                        // Process button
-                        let editorsChoiceItemButton = `<button is='emby-button' class='editorsChoiceItemButton raised button-submit block emby-button'> <span>${getLocalizedString('watchButton')}</span> </button>`;
-
-                        // Sometimes the path will be /web/index.html#/home.html, other times it will be /web/#/home.html
-                        var baseUrl = Emby.Page.baseUrl() + '/';
-                        if (window.location.href.includes('/index.html')) {
-                            baseUrl += 'index.html';
-                        }
-
-                        // Process banner
-                        var bannerImageWidth = Math.max(window.screen.width, window.screen.height);
-                        var bannerImageSize = "";
-                        if (data.reduceImageSizes) {
-                            bannerImageSize = "?width=" + bannerImageWidth;
-                        }
-                        let editorsChoiceItemBanner = `<a href='${baseUrl}#/details?id=${favourite.id}' onclick="Emby.Page.showItem('${favourite.id}'); return false;" class='editorsChoiceItemBanner splide__slide' style="background-image:url('../Items/${favourite.id}/Images/Backdrop/0${bannerImageSize}');"><div> ${editorsChoiceItemLogo} ${editorsChoiceItemRating} ${editorsChoiceItemOverview} ${editorsChoiceItemButton}</div></a>`;
-                        $('#' + containerId + ' .editorsChoiceItemsContainer').append(editorsChoiceItemBanner);
-
-                    });
-
-                    $(elem).addClass('editorsChoiceAdded');
-
-                    if (data.autoplay) {
-                        $('.editorsChoicePlayPauseContainer').show();
-                    }
-
-                    new Splide( '#' + containerId + ' .splide', {
-                        type: 'loop',
-                        autoplay: data.autoplay,
-                        interval: data.autoplayInterval,
-                        pagination: false,
-                        keyboard: true,
-                        height: `${data.bannerHeight}px`
-                      }).mount();
-
-                });
-            });
+        if (!document.querySelector('link[data-editorschoice-splide="1"]')) {
+            const l = document.createElement("link");
+            l.rel = "stylesheet";
+            l.href = "https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/css/splide.min.css";
+            l.setAttribute("data-editorschoice-splide", "1");
+            document.head.appendChild(l);
         }
     });
 }
 
-window.onload = function() {
-    var sliderScript = document.createElement('script');
-    sliderScript.type = 'text/javascript';
-    sliderScript.src = 'https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/js/splide.min.js';
+/* ===== Render ===== */
+function renderHeroSlide(item, data, baseUrl) {
+    const rating = buildRating(item);
+    const logoOrTitle = buildLogoOrTitle(item, data.reduceImageSizes);
+    const overview = buildOverview(item);
 
-    var sliderStyle = document.createElement('link');
-    sliderStyle.rel = 'stylesheet';
-    sliderStyle.href = 'https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/css/splide.min.css';
+    const backdropSize = buildBannerSizeParam(data.reduceImageSizes);
+    const backdropUrl = `../Items/${item.id}/Images/Backdrop/0${backdropSize}`;
 
-    document.head.appendChild(sliderScript);
-    document.head.appendChild(sliderStyle);
+    return `
+  <a href="${baseUrl}#/details?id=${item.id}"
+     onclick="Emby.Page.showItem('${item.id}'); return false;"
+     class="editorsChoiceItemBanner splide__slide">
+    <div class="editorsChoiceBackdrop" style="background-image:url('${backdropUrl}');"></div>
+    <div class="editorsChoiceContent">
+      ${logoOrTitle}
+      ${rating}
+      ${overview}
+    </div>
+  </a>`;
+}
 
-    // Detect if container is ready to setup slider
-    var target = document.getElementById('reactRoot');
+function renderNormalSlide(item, data, baseUrl) {
+    const rating = buildRating(item);
+    const logoOrTitle = buildLogoOrTitle(item, data.reduceImageSizes);
+    const overview = buildOverview(item);
 
-    // Create an observer instance
-    var observer = new MutationObserver(function( mutations ) {
-        mutations.forEach(function( mutation ) {
-            var newNodes = mutation.addedNodes; // DOM NodeList
-            if( newNodes !== null ) { // If there are new nodes added
-                var $nodes = $( newNodes ); // jQuery set
-                $nodes.each(function() {
-                    var $node = $( this );
-                    if( $node.hasClass('section0') && !$node.hasClass('editorsChoiceAdded')) {
-                        setup();
-                    }
+    const bannerSize = buildBannerSizeParam(data.reduceImageSizes);
+    const button = `<button is="emby-button" class="editorsChoiceItemButton raised button-submit block emby-button">
+                    <span>${getLocalizedString("watchButton")}</span>
+                  </button>`;
+
+    return `
+  <a href="${baseUrl}#/details?id=${item.id}"
+     onclick="Emby.Page.showItem('${item.id}'); return false;"
+     class="editorsChoiceItemBanner splide__slide"
+     style="background-image:url('../Items/${item.id}/Images/Backdrop/0${bannerSize}');">
+    <div>
+      ${logoOrTitle}
+      ${rating}
+      ${overview}
+      ${button}
+    </div>
+  </a>`;
+}
+
+/* ===== Main setup ===== */
+async function setup() {
+    console.log("Attempting creation of editors choice slider.");
+
+    const $containers = $(".homeSectionsContainer").filter((_, el) => !$(el).hasClass("editorsChoiceAdded"));
+    if (!$containers.length) return;
+
+    try {
+        await ensureSplideLoaded();
+    } catch (e) {
+        console.warn("Editors Choice: Splide failed to load.", e);
+        return;
+    }
+
+    $containers.each((_, elem) => {
+        console.log("Fetching favourites data from API...");
+
+        ApiClient.fetch({ url: ApiClient.getUrl("/EditorsChoice/favourites"), type: "GET" })
+            .then((response) => response.json())
+            .then((data) => {
+                if (data.hideOnTvLayout && document.documentElement.classList.contains("layout-tv")) {
+                    console.log("Editors Choice: hidden on TV layout by configuration.");
+                    return;
+                }
+
+                const favourites = shuffle(data.favourites || []);
+                const $containerElem = $(container);
+                const containerId = `editorsChoice-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+
+                $containerElem.first().attr("id", containerId);
+                $(elem).prepend($containerElem);
+
+                // TV focus workaround
+                let focusResolved = false;
+                $(`.layout-tv #${containerId} .emby-scrollbuttons button`).on("focus", function () {
+                    if (focusResolved) return;
+                    $('[is="emby-tabs"] .emby-button').first().trigger("focus");
+                    focusResolved = true;
                 });
-            }
-        });
-    });
-    observer.observe(target, {attributes: true, childList: true, characterData: true, subtree: true});
 
-    // Remind user that their favourites will be public when they add a new favourite.
-    $('body').on('click', '[is="emby-ratingbutton"]', function () {
-        if (!$(this).hasClass('ratingbutton-withrating')) {
-            ApiClient.getPluginConfiguration(GUID).then(function (data) {
-                if (ApiClient.getCurrentUserId() == data.EditorUserId) {
-                    Dashboard.confirm("You are the featured items editor! Your favourites will be displayed on the home page for all users, if enabled.");
+                if (data.useHeroLayout) document.body.classList.add("editorsChoiceHeroMode");
+
+                if ("heading" in data && data.heading) {
+                    $($containerElem).prepend(`<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
+                }
+
+                const baseUrl = getBaseUrl();
+                const $list = $(`#${containerId} .editorsChoiceItemsContainer`);
+
+                for (const item of favourites) {
+                    const html = data.useHeroLayout
+                        ? renderHeroSlide(item, data, baseUrl)
+                        : renderNormalSlide(item, data, baseUrl);
+
+                    $list.append(html);
+                }
+
+                $(elem).addClass("editorsChoiceAdded");
+
+                // Toggle autoplay control visibility (button exists: #editorsChoicePlayPause)
+                const playPauseBtn = document.getElementById("editorsChoicePlayPause");
+                if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
+
+                new Splide(`#${containerId} .splide`, {
+                    type: "loop",
+                    autoplay: !!data.autoplay,
+                    interval: data.autoplayInterval,
+                    pagination: false,
+                    keyboard: true,
+                    height: `${data.bannerHeight}px`,
+                }).mount();
+            })
+            .catch((e) => console.warn("Editors Choice: failed to fetch/render.", e));
+    });
+}
+
+window.onload = function () {
+    // Detect if container is ready to setup slider
+    const target = document.getElementById("reactRoot");
+    if (!target) {
+        console.warn("Editors Choice: reactRoot not found.");
+        return;
+    }
+
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            const newNodes = mutation.addedNodes;
+            if (!newNodes || !newNodes.length) continue;
+
+            $(newNodes).each(function () {
+                const $node = $(this);
+                if ($node.hasClass("section0") && !$node.hasClass("editorsChoiceAdded")) {
+                    setup();
                 }
             });
         }
+    });
+
+    observer.observe(target, { attributes: true, childList: true, characterData: true, subtree: true });
+
+    // Remind user that their favourites will be public when they add a new favourite.
+    $("body").on("click", '[is="emby-ratingbutton"]', function () {
+        if ($(this).hasClass("ratingbutton-withrating")) return;
+
+        ApiClient.getPluginConfiguration(GUID).then((data) => {
+            if (ApiClient.getCurrentUserId() === data.EditorUserId) {
+                Dashboard.confirm("You are the featured items editor! Your favourites will be displayed on the home page for all users, if enabled.");
+            }
+        });
     });
 };

--- a/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
+++ b/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
@@ -47,6 +47,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string TransitionEffect { get; set; } = "slide";
 
+    public string HeroBackdropPosition { get; set; } = "center";
+
     public bool ReduceImageSize { get; set; } = false;
 
     public int BannerHeight { get; set; } = 360;

--- a/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
+++ b/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
@@ -33,6 +33,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public int AutoplayInterval { get; set; } = 10;
 
+    public bool ShowPlayButton { get; set; } = true;
+
     public string NewTimeLimit { get; set; } = "1month";
 
     public bool ShowRating { get; set; } = true;
@@ -43,6 +45,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool UseHeroLayout { get; set; } = false;
 
+    public string TransitionEffect { get; set; } = "slide";
+
     public bool ReduceImageSize { get; set; } = false;
 
     public int BannerHeight { get; set; } = 360;
@@ -50,4 +54,5 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool ShowPlayed { get; set; } = true;
 
     public string? Heading { get; set; }
+    public string? PlayButtonText { get; set; }
 }

--- a/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
+++ b/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
@@ -41,6 +41,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool HideOnTvLayout { get; set; } = false;
 
+    public bool UseHeroLayout { get; set; } = false;
+
     public bool ReduceImageSize { get; set; } = false;
 
     public int BannerHeight { get; set; } = 360;

--- a/EditorsChoicePlugin/Configuration/configPage.html
+++ b/EditorsChoicePlugin/Configuration/configPage.html
@@ -10,7 +10,7 @@
                 box-sizing: border-box;
                 display: inline-block;
                 line-height: 24px;
-                margin: 0px;
+                margin: 0;
                 position: relative;
             }
 
@@ -26,9 +26,9 @@
                 border: none;
                 height: 1px;
                 line-height: 24px;
-                margin: 0px;
+                margin: 0;
                 opacity: 0;
-                padding: 0px;
+                padding: 0;
                 position: absolute;
                 width: 1px;
             }
@@ -53,17 +53,17 @@
                 height: 100%;
                 overflow: visible;
                 position: absolute;
-                top: 0px;
+                top: 0;
                 width: 100%;
                 z-index: 1;
             }
 
             [dir="ltr"] .mdl-radio__circles svg {
-                left: 0px;
+                left: 0;
             }
 
             [dir="rtl"] .mdl-radio__circles svg {
-                right: 0px;
+                right: 0;
             }
 
             .mdl-radio__button:disabled + .mdl-radio__circles {
@@ -102,11 +102,11 @@
                 border-radius: 50%;
                 box-sizing: border-box;
                 height: 100%;
-                left: 0px;
-                margin: 0px;
+                left: 0;
+                margin: 0;
                 opacity: 0.26;
                 position: absolute;
-                top: 0px;
+                top: 0;
                 transform: scale(0);
                 transition-duration: 0.2s;
                 transition-property: transform, -webkit-transform;
@@ -134,52 +134,94 @@
                 width: 100%;
             }
 
+            .editorsChoiceConfigurationForm hr {
+                border-color: #292929c2;
+            }
+
         </style>
 
         <div data-role="content">
             <div class="content-primary">
-
                 <form class="editorsChoiceConfigurationForm">
-                    <br>
                     <h1>EditorsChoice settings</h1>
-                    <h2>Mode</h2>
 
+                    <hr />
+                    <h2>Mode</h2>
                     <div class="inputContainer">
                         <label class="radio-label-block mdl-radio show-focus">
-                            <input type="radio" is="emby-radio" id="FavouritesMode" name="mode" value="FavouritesMode" class="mdl-radio__button"/>
-                            <div class="mdl-radio__circles"><svg><defs><clipPath id="cutoff"><circle cx="50%" cy="50%" r="50%"></circle></clipPath></defs><circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff)"></circle><circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle></svg><div class="mdl-radio__focus-circle"></div></div>
+                            <input type="radio" is="emby-radio" id="FavouritesMode" name="mode" value="FavouritesMode" class="mdl-radio__button" />
+                            <div class="mdl-radio__circles">
+                                <svg>
+                                    <defs>
+                                        <clipPath id="cutoff-fav"><circle cx="50%" cy="50%" r="50%"></circle></clipPath>
+                                    </defs>
+                                    <circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff-fav)"></circle>
+                                    <circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle>
+                                </svg>
+                                <div class="mdl-radio__focus-circle"></div>
+                            </div>
                             <span class="radioButtonLabel mdl-radio__label">Favourites</span>
                             <div class="fieldDescription">Shows items from the specified user's favourites</div>
                         </label>
+
                         <label class="radio-label-block mdl-radio show-focus">
-                            <input type="radio" is="emby-radio" id="RandomMode" name="mode" value="RandomMode" class="mdl-radio__button"/>
-                            <div class="mdl-radio__circles"><svg><defs><clipPath id="cutoff"><circle cx="50%" cy="50%" r="50%"></circle></clipPath></defs><circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff)"></circle><circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle></svg><div class="mdl-radio__focus-circle"></div></div>
+                            <input type="radio" is="emby-radio" id="RandomMode" name="mode" value="RandomMode" class="mdl-radio__button" />
+                            <div class="mdl-radio__circles">
+                                <svg>
+                                    <defs>
+                                        <clipPath id="cutoff-rand"><circle cx="50%" cy="50%" r="50%"></circle></clipPath>
+                                    </defs>
+                                    <circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff-rand)"></circle>
+                                    <circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle>
+                                </svg>
+                                <div class="mdl-radio__focus-circle"></div>
+                            </div>
                             <span class="radioButtonLabel mdl-radio__label">Random</span>
                             <div class="fieldDescription">Shows a random selection of items from your library</div>
                         </label>
+
                         <label class="radio-label-block mdl-radio show-focus">
-                            <input type="radio" is="emby-radio" id="CollectionsMode" name="mode" value="CollectionsMode" class="mdl-radio__button"/>
-                            <div class="mdl-radio__circles"><svg><defs><clipPath id="cutoff"><circle cx="50%" cy="50%" r="50%"></circle></clipPath></defs><circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff)"></circle><circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle></svg><div class="mdl-radio__focus-circle"></div></div>
+                            <input type="radio" is="emby-radio" id="CollectionsMode" name="mode" value="CollectionsMode" class="mdl-radio__button" />
+                            <div class="mdl-radio__circles">
+                                <svg>
+                                    <defs>
+                                        <clipPath id="cutoff-col"><circle cx="50%" cy="50%" r="50%"></circle></clipPath>
+                                    </defs>
+                                    <circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff-col)"></circle>
+                                    <circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle>
+                                </svg>
+                                <div class="mdl-radio__focus-circle"></div>
+                            </div>
                             <span class="radioButtonLabel mdl-radio__label">Collections</span>
                             <div class="fieldDescription">Shows items from the specified collections</div>
                         </label>
+
                         <label class="radio-label-block mdl-radio show-focus">
-                            <input type="radio" is="emby-radio" id="NewMode" name="mode" value="NewMode" class="mdl-radio__button"/>
-                            <div class="mdl-radio__circles"><svg><defs><clipPath id="cutoff"><circle cx="50%" cy="50%" r="50%"></circle></clipPath></defs><circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff)"></circle><circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle></svg><div class="mdl-radio__focus-circle"></div></div>
+                            <input type="radio" is="emby-radio" id="NewMode" name="mode" value="NewMode" class="mdl-radio__button" />
+                            <div class="mdl-radio__circles">
+                                <svg>
+                                    <defs>
+                                        <clipPath id="cutoff-new"><circle cx="50%" cy="50%" r="50%"></circle></clipPath>
+                                    </defs>
+                                    <circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff-new)"></circle>
+                                    <circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle>
+                                </svg>
+                                <div class="mdl-radio__focus-circle"></div>
+                            </div>
                             <span class="radioButtonLabel mdl-radio__label">New</span>
                             <div class="fieldDescription">Shows only items released in the last 6 months</div>
                         </label>
                     </div>
 
-                    <div id="EditorUserId-container" class="selectContainer" style="display: none;">
+                    <div id="EditorUserId-container" class="selectContainer" style="display:none;">
                         <label class="selectLabel" for="EditorUserId">User's favourites list</label>
                         <select is="emby-select" id="EditorUserId" name="EditorUserId" class="emby-select-withcolor emby-select">
                             <option value="none">None</option>
                         </select>
                     </div>
 
-                    <div id="NewTimeLimit-container" style="display: none;">
-                        <h3 class="selectLabel">Show items released in the last:</h3>
+                    <div id="NewTimeLimit-container" class="selectContainer" style="display:none;">
+                        <label class="selectLabel" for="NewTimeLimitSelect">Show items released in the last:</label>
                         <select is="emby-select" id="NewTimeLimitSelect" name="NewTimeLimit" class="emby-select-withcolor emby-select">
                             <option value="1month">1 month</option>
                             <option value="2month">2 months</option>
@@ -188,43 +230,48 @@
                             <option value="2year">2 years</option>
                             <option value="5year">5 years</option>
                         </select>
-                        <br/>
                     </div>
 
-                    <div id="CollectionsList-container" style="display: none;">
+                    <div id="CollectionsList-container" style="display:none;">
                         <h3 class="checkboxListLabel">Show items from these collections:</h3>
                         <div id="CollectionsList" class="checkboxList"></div>
                         <p>One collection will be shown at a time across the slider. If multiple are checked below, one of them will be randomly chosen each time it loads.</p>
                     </div>
 
+                    <hr />
                     <h2>Autoplay</h2>
 
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="EnableAutoplay" name="Enable autoplay" label="Enable autoplay">
-                            <span>Enable autoplay</span>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="EnableAutoplay" name="EnableAutoplay" />
+                            <span class="checkboxLabel">Enable autoplay</span>
                         </label>
                     </div>
 
-                    <div id="AutoplayInterval-container" class="inputContainer" style="display: none;">
-                        <input is="emby-input" type="number" id="AutoplayInterval" name="Autoplay interval" label="Autoplay interval" min="1" step="1">
+                    <div id="AutoplayInterval-container" class="inputContainer" style="display:none;">
+                        <label class="inputLabel inputLabelUnfocused" for="AutoplayInterval">Autoplay interval</label>
+                        <input is="emby-input" type="number" id="AutoplayInterval" name="AutoplayInterval" min="1" step="1" />
                         <div class="fieldDescription">How often, in seconds, the slider moves to the next item. Default is 10 seconds.</div>
                     </div>
 
+                    <hr />
                     <h2>Filtering</h2>
 
                     <div class="inputContainer">
-                        <input is="emby-input" type="number" id="RandomMediaCount" name="Media count" label="Maximum items shown" min="1">
+                        <label class="inputLabel inputLabelUnfocused" for="RandomMediaCount">Maximum items shown</label>
+                        <input is="emby-input" type="number" id="RandomMediaCount" name="RandomMediaCount" min="1" />
                         <div class="fieldDescription">This sets how many items to show in the banner, whether random or from the favourites list. Set to a massive number if you want to show all of your favourited items.</div>
                     </div>
 
                     <div class="inputContainer">
-                        <input is="emby-input" type="number" id="MinimumRating" name="Minimum community rating" label="Minimum community rating" min="0" max="10" step="0.1">
+                        <label class="inputLabel inputLabelUnfocused" for="MinimumRating">Minimum community rating</label>
+                        <input is="emby-input" type="number" id="MinimumRating" name="MinimumRating" min="0" max="10" step="0.1" />
                         <div class="fieldDescription">Only show shows or films that have a community rating at least this number (0.0 to 10.0). Set to 0 to ignore rating.</div>
                     </div>
 
                     <div class="inputContainer">
-                        <input is="emby-input" type="number" id="MinimumCriticRating" name="Minimum critic rating" label="Minimum critic rating" min="0" max="100" step="1">
+                        <label class="inputLabel inputLabelUnfocused" for="MinimumCriticRating">Minimum critic rating</label>
+                        <input is="emby-input" type="number" id="MinimumCriticRating" name="MinimumCriticRating" min="0" max="100" step="1" />
                         <div class="fieldDescription">Only show shows or films that have a critic rating at least this number (0 to 100). Set to 0 to ignore rating.</div>
                     </div>
 
@@ -236,106 +283,132 @@
                         <div class="fieldDescription">Items with a parental rating higher than this will not be shown. Set to 'User profile' to limit to a user's specific parental access controls (default).</div>
                     </div>
 
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="ShowPlayed" name="Show played" label="Show played">
-                            <span>Show played items</span>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="ShowPlayed" name="ShowPlayed" />
+                            <span class="checkboxLabel">Show played items</span>
                         </label>
                     </div>
 
+                    <hr />
                     <h2>Display</h2>
+
                     <div class="inputContainer">
                         <label class="inputLabel inputLabelUnfocused" for="Heading">Banner heading</label>
-                        <input is="emby-input" type="text" id="Heading" label="Banner heading" class="emby-input">
+                        <input is="emby-input" type="text" id="Heading" name="Heading" />
                         <div class="fieldDescription">Add a heading above the banner. Leave empty for no heading.</div>
                     </div>
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="ShowPlayButton" name="Show Play Button" label="Show Play Button">
-                            <span>Show Play Button</span>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="ShowPlayButton" name="ShowPlayButton" />
+                            <span class="checkboxLabel">Show Play Button</span>
                         </label>
                     </div>
+
                     <div class="inputContainer">
                         <label class="inputLabel inputLabelUnfocused" for="PlayButtonText">Custom Play Button Text</label>
-                        <input is="emby-input" type="text" id="PlayButtonText" label="Custom Play Button Text" class="emby-input">
+                        <input is="emby-input" type="text" id="PlayButtonText" name="PlayButtonText" />
                         <div class="fieldDescription">Change the default Play Button Text. Leave empty for default.</div>
                     </div>
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="ShowRating" name="Show rating" label="Show rating">
-                            <span>Show community rating</span>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="ShowRating" name="ShowRating" />
+                            <span class="checkboxLabel">Show community rating</span>
                         </label>
                     </div>
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="ShowDesc" name="Show description" label="Show description">
-                            <span>Show description</span>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="ShowDesc" name="ShowDesc" />
+                            <span class="checkboxLabel">Show description</span>
                         </label>
                     </div>
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="HideOnTvLayout" name="Hide on TV layout" label="Hide on TV layout">
-                            <span>Hide on TVs</span>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="HideOnTvLayout" name="HideOnTvLayout" />
+                            <span class="checkboxLabel">Hide on TVs</span>
                         </label>
                         <div class="fieldDescription">When enabled, the Editors Choice banner will not be injected on TV interfaces.</div>
                     </div>
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="UseHeroLayout" name="Use Hero Display Style" label="Use Hero Display Style">
-                            <span>Use Hero Display Style</span>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="UseHeroLayout" name="UseHeroLayout" />
+                            <span class="checkboxLabel">Use Hero Display Style</span>
                         </label>
                         <div class="fieldDescription">Changes the banner layout to a hero-style display. Recommended banner height: Large or higher.</div>
                     </div>
+
+                    <div id="HeroBackdropPosition-container" class="selectContainer">
+                        <label class="selectLabel" for="HeroBackdropPositionSelect">Image Position (Hero Style):</label>
+                        <select is="emby-select" id="HeroBackdropPositionSelect" name="HeroBackdropPositionSelect" class="emby-select-withcolor emby-select">
+                            <option value="center">Center (Default)</option>
+                            <option value="top">Top</option>
+                            <option value="bottom">Bottom</option>
+                        </select>
+                    </div>
+
                     <div id="effect-container" class="selectContainer">
-                        <h3 class="selectLabel">Transition Effect:</h3>
+                        <label class="selectLabel" for="TransitionEffectSelect">Transition Effect:</label>
                         <select is="emby-select" id="TransitionEffectSelect" name="TransitionEffectSelect" class="emby-select-withcolor emby-select">
                             <option value="slide">Slide (Default)</option>
                             <option value="fade">Fade</option>
                         </select>
-                        <br/>
                     </div>
+
                     <div id="BannerHeight-container" class="selectContainer">
-                        <h3 class="selectLabel">Height of banner:</h3>
+                        <label class="selectLabel" for="BannerHeightSelect">Height of banner:</label>
                         <select is="emby-select" id="BannerHeightSelect" name="BannerHeight" class="emby-select-withcolor emby-select">
                             <option value="360">Slim (Default)</option>
                             <option value="400">Thick</option>
                             <option value="500">Large</option>
                             <option value="600">Huge</option>
                         </select>
-                        <br/>
                     </div>
 
+                    <hr />
                     <h2>Technical settings</h2>
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="DoScriptInject" name="Enable client script injection" label="Enable client script injection">
-                            <span>Enable client script injection</span>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="DoScriptInject" name="DoScriptInject" />
+                            <span class="checkboxLabel">Enable client script injection</span>
                         </label>
                         <div class="fieldDescription">This will depend on permissions for the jellyfin-web index.html file. Toggling this mode will take effect after the next restart.</div>
                     </div>
 
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="FileTransformation" name="Use FileTransformation plugin" label="Use FileTransformation plugin">
-                            <span>Use FileTransformation plugin (recommended)</span>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="FileTransformation" name="FileTransformation" />
+                            <span class="checkboxLabel">Use FileTransformation plugin (recommended)</span>
                         </label>
-                        <div class="fieldDescription">Using <a href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank">the FileTransformation plugin</a> is the easiest way to inject the required script to the Jellyfin homepage. Toggling this mode will take effect after the next restart.</div>
+                        <div class="fieldDescription">
+                            Using <a href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank" rel="noopener noreferrer">the FileTransformation plugin</a>
+                            is the easiest way to inject the required script to the Jellyfin homepage. Toggling this mode will take effect after the next restart.
+                        </div>
                     </div>
 
-                    <div class="checkboxContainer">
-                        <label>
-                            <input is="emby-checkbox"  type="checkbox" id="ReduceImageSize" name="Reduce image sizes" label="Reduce image sizes">
-                            <span>Reduce image sizes.</span>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="ReduceImageSize" name="ReduceImageSize" />
+                            <span class="checkboxLabel">Reduce image sizes</span>
                         </label>
                         <div class="fieldDescription">This will make banner and logo images load faster for users and reduce network usage, but increase processing demand on your media server. Turn off if plugin is having a significant performance impact.</div>
                     </div>
 
+                    <hr />
                     <div>
-                        <button is="emby-button" type="submit" class="raised button-submit block emby-button"><span>Save</span></button>
+                        <button is="emby-button" type="submit" class="raised button-submit block emby-button">
+                            <span>Save</span>
+                        </button>
                     </div>
                 </form>
             </div>
         </div>
+
 
         <script type="text/javascript">
 
@@ -372,6 +445,7 @@
                         $('#ReduceImageSize').first().prop('checked', config.ReduceImageSize);
                         $("#BannerHeightSelect").val(config.BannerHeight);
                         $("#TransitionEffectSelect").val(config.TransitionEffect);
+                        $("#HeroBackdropPositionSelect").val(config.HeroBackdropPosition);
                         $("#UseHeroLayout").first().prop('checked', config.UseHeroLayout);
 
                         $('#ShowPlayed').first().prop('checked', config.ShowPlayed);
@@ -514,6 +588,7 @@
                         config.HideOnTvLayout = $('#HideOnTvLayout').first().is(':checked');
                         config.UseHeroLayout = $('#UseHeroLayout').first().is(':checked');
                         config.TransitionEffect = $("#TransitionEffectSelect").val();
+                        config.HeroBackdropPosition = $("#HeroBackdropPositionSelect").val();
 
                         if ($('#FavouritesMode').first().is(':checked')) {
                             config.Mode = "FAVOURITES";

--- a/EditorsChoicePlugin/Configuration/configPage.html
+++ b/EditorsChoicePlugin/Configuration/configPage.html
@@ -268,6 +268,12 @@
                         </label>
                         <div class="fieldDescription">When enabled, the Editors Choice banner will not be injected on TV interfaces.</div>
                     </div>
+                    <div class="checkboxContainer">
+                        <label>
+                            <input is="emby-checkbox"  type="checkbox" id="UseHeroLayout" name="Use Hero Display Style" label="Use Hero Display Style">
+                            <span>Use Hero Display Style</span>
+                        </label>
+                    </div>
                     <div id="BannerHeight-container" class="selectContainer">
                         <h3 class="selectLabel">Height of banner:</h3>
                         <select is="emby-select" id="BannerHeightSelect" name="BannerHeight" class="emby-select-withcolor emby-select">
@@ -344,6 +350,7 @@
                         $('#ShowDesc').first().prop('checked', config.ShowDescription);
                         $('#ReduceImageSize').first().prop('checked', config.ReduceImageSize);
                         $("#BannerHeightSelect").val(config.BannerHeight);
+                        $("UseHeroLayout").first().prop('checked', config.UseHeroLayout);
                         $('#ShowPlayed').first().prop('checked', config.ShowPlayed);
                         $("#Heading").val(config.Heading);
                         $('#HideOnTvLayout').first().prop('checked', config.HideOnTvLayout);
@@ -480,6 +487,7 @@
                         config.ReduceImageSize = $('#ReduceImageSize').first().is(':checked');
                         config.ShowPlayed = $('#ShowPlayed').first().is(':checked');
                         config.HideOnTvLayout = $('#HideOnTvLayout').first().is(':checked');
+                        config.UseHeroLayout = $('#UseHeroLayout').first().is(':checked');
 
                         if ($('#FavouritesMode').first().is(':checked')) {
                             config.Mode = "FAVOURITES";

--- a/EditorsChoicePlugin/Configuration/configPage.html
+++ b/EditorsChoicePlugin/Configuration/configPage.html
@@ -251,6 +251,17 @@
                     </div>
                     <div class="checkboxContainer">
                         <label>
+                            <input is="emby-checkbox"  type="checkbox" id="ShowPlayButton" name="Show Play Button" label="Show Play Button">
+                            <span>Show Play Button</span>
+                        </label>
+                    </div>
+                    <div class="inputContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="PlayButtonText">Custom Play Button Text</label>
+                        <input is="emby-input" type="text" id="PlayButtonText" label="Custom Play Button Text" class="emby-input">
+                        <div class="fieldDescription">Change the default Play Button Text. Leave empty for default.</div>
+                    </div>
+                    <div class="checkboxContainer">
+                        <label>
                             <input is="emby-checkbox"  type="checkbox" id="ShowRating" name="Show rating" label="Show rating">
                             <span>Show community rating</span>
                         </label>
@@ -273,6 +284,15 @@
                             <input is="emby-checkbox"  type="checkbox" id="UseHeroLayout" name="Use Hero Display Style" label="Use Hero Display Style">
                             <span>Use Hero Display Style</span>
                         </label>
+                        <div class="fieldDescription">Changes the banner layout to a hero-style display. Recommended banner height: Large or higher.</div>
+                    </div>
+                    <div id="effect-container" class="selectContainer">
+                        <h3 class="selectLabel">Transition Effect:</h3>
+                        <select is="emby-select" id="TransitionEffectSelect" name="TransitionEffectSelect" class="emby-select-withcolor emby-select">
+                            <option value="slide">Slide (Default)</option>
+                            <option value="fade">Fade</option>
+                        </select>
+                        <br/>
                     </div>
                     <div id="BannerHeight-container" class="selectContainer">
                         <h3 class="selectLabel">Height of banner:</h3>
@@ -348,11 +368,15 @@
                         $("#NewTimeLimitSelect").val(config.NewTimeLimit);
                         $('#ShowRating').first().prop('checked', config.ShowRating);
                         $('#ShowDesc').first().prop('checked', config.ShowDescription);
+                        $('#ShowPlayButton').first().prop('checked', config.ShowPlayButton);
                         $('#ReduceImageSize').first().prop('checked', config.ReduceImageSize);
                         $("#BannerHeightSelect").val(config.BannerHeight);
-                        $("UseHeroLayout").first().prop('checked', config.UseHeroLayout);
+                        $("#TransitionEffectSelect").val(config.TransitionEffect);
+                        $("#UseHeroLayout").first().prop('checked', config.UseHeroLayout);
+
                         $('#ShowPlayed').first().prop('checked', config.ShowPlayed);
                         $("#Heading").val(config.Heading);
+                        $("#PlayButtonText").val(config.PlayButtonText);
                         $('#HideOnTvLayout').first().prop('checked', config.HideOnTvLayout);
 
                         if (config.Mode == 'FAVOURITES') {
@@ -484,10 +508,12 @@
                         config.AutoplayInterval = $('#AutoplayInterval').first().val();
                         config.ShowRating = $('#ShowRating').first().is(':checked');
                         config.ShowDescription =  $('#ShowDesc').first().is(':checked');
+                        config.ShowPlayButton = $('#ShowPlayButton').first().is(':checked');
                         config.ReduceImageSize = $('#ReduceImageSize').first().is(':checked');
                         config.ShowPlayed = $('#ShowPlayed').first().is(':checked');
                         config.HideOnTvLayout = $('#HideOnTvLayout').first().is(':checked');
                         config.UseHeroLayout = $('#UseHeroLayout').first().is(':checked');
+                        config.TransitionEffect = $("#TransitionEffectSelect").val();
 
                         if ($('#FavouritesMode').first().is(':checked')) {
                             config.Mode = "FAVOURITES";
@@ -543,6 +569,7 @@
                         config.NewTimeLimit = $("#NewTimeLimitSelect").val();
                         config.BannerHeight = $("#BannerHeightSelect").val();
                         config.Heading = $('#Heading').first().val();
+                        config.PlayButtonText = $('#PlayButtonText').first().val();
 
                         ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
 


### PR DESCRIPTION
Hey! 👋

I added a few display customization options that I personally wanted to better fine-tune the banner appearance and took the opportunity to refactor parts of client.js and the configuration page to make things more readable and consistent.

This includes options like toggling the play button, customizing its text, selecting the transition effect (Slide / Fade) and adjusting the backdrop position in Hero mode.

This has been working well on my end together with the [ElegantFin](https://github.com/lscambo13/ElegantFin) theme.

### Screenshots
**Before**
<img width="1600" height="619" alt="Before" src="https://github.com/user-attachments/assets/cde0c870-ea50-4852-a05c-15fadaaff942" />

**After**
<img width="1600" height="586" alt="After" src="https://github.com/user-attachments/assets/09bfb3e0-b498-4bf3-beed-fd3adf18cd33" />

### Notes
- This is currently a draft / WIP.
- I’d love feedback on the UX
- Tested on:  iOS Jellyfin App, Brave/Chromium

Feedback welcome 🙏