### PR TITLE
Add Jellyfin 12 support

### DIFF
--- a/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
+++ b/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
@@ -144,7 +144,7 @@ public class EditorsChoiceActivityController : ControllerBase
                         OrderBy = new[] { (ItemSortBy.Random, SortOrder.Ascending) }
                     };
                     query.Limit = _config.RandomMediaCount * 2;
-                    initialResult = (List<BaseItem>)_libraryManager.GetItemList(query);
+                    initialResult = _libraryManager.GetItemList(query).ToList();
 
                     // Get ids of items in the favourites list
                     List<Guid> itemIds = new List<Guid>();
@@ -259,7 +259,7 @@ public class EditorsChoiceActivityController : ControllerBase
                     OrderBy = new[] { (ItemSortBy.Random, SortOrder.Descending) },
                     IsPlayed = _config.ShowPlayed ? null : false
                 };
-                initialResult = (List<BaseItem>)_libraryManager.GetItemList(queryItems);
+                initialResult = _libraryManager.GetItemList(queryItems).ToList();
 
                 // Of TV series that meet those criteria, loop through to find items that are recent enough. These are already ordered by recency, so can quit on first item that is too old.
                 List<Guid> itemIds = new List<Guid>();
@@ -272,7 +272,7 @@ public class EditorsChoiceActivityController : ControllerBase
                         ParentId = item.Id,
                         OrderBy = new[] { (ItemSortBy.IndexNumber, SortOrder.Descending )}
                     };
-                    List<BaseItem> seasons = (List<BaseItem>) _libraryManager.GetItemList(querySeasons);
+                    List<BaseItem> seasons = _libraryManager.GetItemList(querySeasons).ToList();
 
                     if (seasons.Count > 0) {
                         Guid latestSeasonId = seasons[0].Id;
@@ -285,7 +285,7 @@ public class EditorsChoiceActivityController : ControllerBase
                             ParentId = latestSeasonId,
                             OrderBy = new[] { (ItemSortBy.IndexNumber, SortOrder.Descending) }
                         };
-                        List<BaseItem> episodes = (List<BaseItem>) _libraryManager.GetItemList(queryEpisodes);
+                        List<BaseItem> episodes = _libraryManager.GetItemList(queryEpisodes).ToList();
                         
                         //_logger.LogInformation("Contains {0} episodes.", episodes.Count);
 
@@ -319,7 +319,7 @@ public class EditorsChoiceActivityController : ControllerBase
                     IsPlayed = _config.ShowPlayed ? null : false
                 };
                 queryMovies.Limit = _config.RandomMediaCount;
-                List<BaseItem> resultMovies = (List<BaseItem>) _libraryManager.GetItemList(queryMovies);
+                List<BaseItem> resultMovies = _libraryManager.GetItemList(queryMovies).ToList();
 
                 // Join the lists of recent films and recent series
                 foreach (BaseItem item in resultMovies) itemIds.Add(item.Id);
@@ -411,15 +411,15 @@ public class EditorsChoiceActivityController : ControllerBase
         }
         catch (Exception e)
         {
-            _logger.LogError(e.ToString());
-            return StatusCode(503);
+            _logger.LogError(e, "Failed to build the Editors Choice response.");
+            return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
     }
 
     private List<BaseItem> PrepareResult(InternalItemsQuery query, Jellyfin.Database.Implementations.Entities.User? activeUser)
     {
-        List<BaseItem> initialResult = (List<BaseItem>)_libraryManager.GetItemList(query);
+        List<BaseItem> initialResult = _libraryManager.GetItemList(query).ToList();
         List<BaseItem> result = [];
 
         // Randomly add items until we run out or reach the admin-set cap

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -8,7 +8,7 @@ const container = `
           <span class="material-icons chevron_left" aria-hidden="true"></span>
         </button>
 
-        <button class="splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button" id="editorsChoicePlayPause">
+        <button class="editorsChoicePlayPause splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button">
           <span class="splide__toggle__play material-icons play_arrow" aria-hidden="true"></span>
           <span class="splide__toggle__pause material-icons pause" aria-hidden="true"></span>
         </button>
@@ -184,7 +184,7 @@ const container = `
 
   /* ===== Hero mode ===== */
   .editorsChoiceHeroMode .editorsChoiceContainer { padding: 0 !important; }
-  .editorsChoiceHeroMode #homeTab { transform: translateY(-120px); }
+  #homeTab.editorsChoiceHeroMode { transform: translateY(-120px); }
 
   .editorsChoiceHeroMode .splide.cardScalable {
     border-radius: unset !important;
@@ -278,6 +278,9 @@ const container = `
 `;
 
 const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
+const HOME_CONTAINER_SELECTOR = "#indexPage:not(.hide) #homeTab.is-active .homeSectionsContainer";
+const EDITORS_CHOICE_ADDED_CLASS = "editorsChoiceAdded";
+const EDITORS_CHOICE_LOADING_CLASS = "editorsChoiceLoading";
 
 /* ===== Utils ===== */
 function shuffle(input) {
@@ -442,8 +445,11 @@ function renderNormalSlide(item, data, baseUrl) {
 async function setup() {
     console.log("Attempting creation of editors choice slider.");
 
-    const $containers = $(".homeSectionsContainer").filter((_, el) => !$(el).hasClass("editorsChoiceAdded"));
-    if (!$containers.length) return;
+    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => (
+        !element.classList.contains(EDITORS_CHOICE_ADDED_CLASS)
+        && !element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)
+    ));
+    if (!containers.length) return;
 
     try {
         await ensureSplideLoaded();
@@ -452,57 +458,65 @@ async function setup() {
         return;
     }
 
-    $containers.each((_, elem) => {
+    for (const elem of containers) {
         console.log("Fetching favourites data from API...");
+        elem.classList.add(EDITORS_CHOICE_LOADING_CLASS);
 
         ApiClient.fetch({ url: ApiClient.getUrl("/EditorsChoice/favourites"), type: "GET" })
             .then((response) => response.json())
             .then((data) => {
                 if (data.hideOnTvLayout && document.documentElement.classList.contains("layout-tv")) {
                     console.log("Editors Choice: hidden on TV layout by configuration.");
+                    elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
                     return;
                 }
 
                 const favourites = shuffle(data.favourites || []);
-                const $containerElem = $(container);
+                const template = document.createElement("template");
+                template.innerHTML = container.trim();
+                const content = template.content.cloneNode(true);
+                const containerElem = content.querySelector(".editorsChoiceContainer");
                 const containerId = `editorsChoice-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 
-                $containerElem.first().attr("id", containerId);
-                $containerElem.first().addClass(`editorsChoiceHeight-${data.bannerHeight}`);
-                $(elem).prepend($containerElem);
+                containerElem.id = containerId;
+                containerElem.classList.add(`editorsChoiceHeight-${data.bannerHeight}`);
+                elem.prepend(content);
 
                 // TV focus workaround
                 let focusResolved = false;
-                $(`.layout-tv #${containerId} .emby-scrollbuttons button`).on("focus", function () {
-                    if (focusResolved) return;
-                    $('[is="emby-tabs"] .emby-button').first().trigger("focus");
-                    focusResolved = true;
+                containerElem.querySelectorAll(".emby-scrollbuttons button").forEach((button) => {
+                    button.addEventListener("focus", () => {
+                        if (focusResolved || !document.documentElement.classList.contains("layout-tv")) return;
+                        document.querySelector('[is="emby-tabs"] .emby-button')?.focus();
+                        focusResolved = true;
+                    });
                 });
 
-                if (data.useHeroLayout) document.body.classList.add("editorsChoiceHeroMode");
+                const homeTab = elem.closest("#homeTab");
+                if (homeTab) homeTab.classList.toggle("editorsChoiceHeroMode", !!data.useHeroLayout);
 
                 if ("heading" in data && data.heading && !data.useHeroLayout) {
-                    $($containerElem).prepend(`<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
+                    containerElem.insertAdjacentHTML("afterbegin", `<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
                 }
 
                 const baseUrl = getBaseUrl();
-                const $list = $(`#${containerId} .editorsChoiceItemsContainer`);
+                const list = containerElem.querySelector(".editorsChoiceItemsContainer");
 
                 for (const item of favourites) {
                     const html = data.useHeroLayout
                         ? renderHeroSlide(item, data, baseUrl)
                         : renderNormalSlide(item, data, baseUrl);
 
-                    $list.append(html);
+                    list.insertAdjacentHTML("beforeend", html);
                 }
 
-                $(elem).addClass("editorsChoiceAdded");
+                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
 
-                // Toggle autoplay control visibility (button exists: #editorsChoicePlayPause)
-                const playPauseBtn = document.getElementById("editorsChoicePlayPause");
+                // Toggle autoplay control visibility.
+                const playPauseBtn = containerElem.querySelector(".editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
 
-                new Splide(`#${containerId} .splide`, {
+                new Splide(containerElem.querySelector(".splide"), {
                     type: data.transitionEffect ?? "loop",
                     autoplay: !!data.autoplay,
                     rewind: true,
@@ -512,37 +526,76 @@ async function setup() {
                     height: `${data.bannerHeight + (data.useHeroLayout ? 180 : 0)}px`, // Add 80px to the banner image height in hero mode to compensate for navbar overlay
                 }).mount();
             })
-            .catch((e) => console.warn("Editors Choice: failed to fetch/render.", e));
+            .catch((e) => {
+                elem.classList.remove(EDITORS_CHOICE_ADDED_CLASS);
+                console.warn("Editors Choice: failed to fetch/render.", e);
+            })
+            .finally(() => elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS));
+    }
+}
+
+let setupScheduled = false;
+
+function scheduleSetup() {
+    if (setupScheduled) return;
+
+    setupScheduled = true;
+    window.requestAnimationFrame(() => {
+        setupScheduled = false;
+        setup();
     });
 }
 
-window.onload = function () {
-    // Detect if container is ready to setup slider
-    const target = document.getElementById("reactRoot");
+function nodeContainsHomeContainer(node) {
+    if (!(node instanceof Element)) return false;
+
+    return node.matches(HOME_CONTAINER_SELECTOR)
+        || !!node.querySelector(HOME_CONTAINER_SELECTOR)
+        || !!node.closest(HOME_CONTAINER_SELECTOR);
+}
+
+function initializeEditorsChoice() {
+    // Jellyfin 12 mounts the legacy home tab as a nested React subtree. Observe
+    // the React root when available and fall back to body for older web clients.
+    const target = document.getElementById("reactRoot") || document.body;
     if (!target) {
-        console.warn("Editors Choice: reactRoot not found.");
+        console.warn("Editors Choice: page root not found.");
         return;
     }
 
     const observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
-            const newNodes = mutation.addedNodes;
-            if (!newNodes || !newNodes.length) continue;
-
-            $(newNodes).each(function () {
-                const $node = $(this);
-                if ($node.hasClass("section0") && !$node.hasClass("editorsChoiceAdded")) {
-                    setup();
+            if (mutation.type === "attributes") {
+                const element = mutation.target;
+                if (element instanceof Element && element.matches("#indexPage, #homeTab")) {
+                    scheduleSetup();
+                    return;
                 }
-            });
+            }
+
+            for (const node of mutation.addedNodes) {
+                if (nodeContainsHomeContainer(node)) {
+                    scheduleSetup();
+                    return;
+                }
+            }
         }
     });
 
-    observer.observe(target, { attributes: true, childList: true, characterData: true, subtree: true });
+    observer.observe(target, {
+        attributes: true,
+        attributeFilter: ["class"],
+        childList: true,
+        subtree: true,
+    });
+
+    // The script can be loaded after the home tab has already mounted.
+    scheduleSetup();
 
     // Remind user that their favourites will be public when they add a new favourite.
-    $("body").on("click", '[is="emby-ratingbutton"]', function () {
-        if ($(this).hasClass("ratingbutton-withrating")) return;
+    document.body.addEventListener("click", (event) => {
+        const ratingButton = event.target.closest?.('[is="emby-ratingbutton"]');
+        if (!ratingButton || ratingButton.classList.contains("ratingbutton-withrating")) return;
 
         ApiClient.getPluginConfiguration(GUID).then((data) => {
             if (ApiClient.getCurrentUserId() === data.EditorUserId) {
@@ -550,4 +603,10 @@ window.onload = function () {
             }
         });
     });
-};
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeEditorsChoice, { once: true });
+} else {
+    initializeEditorsChoice();
+}

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -281,6 +281,8 @@ const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
 const HOME_CONTAINER_SELECTOR = "#indexPage:not(.hide) #homeTab.is-active .homeSectionsContainer";
 const EDITORS_CHOICE_ADDED_CLASS = "editorsChoiceAdded";
 const EDITORS_CHOICE_LOADING_CLASS = "editorsChoiceLoading";
+const initializingContainers = new WeakSet();
+const initializedContainers = new WeakSet();
 
 /* ===== Utils ===== */
 function shuffle(input) {
@@ -445,28 +447,61 @@ function renderNormalSlide(item, data, baseUrl) {
 async function setup() {
     console.log("Attempting creation of editors choice slider.");
 
-    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => (
-        !element.classList.contains(EDITORS_CHOICE_ADDED_CLASS)
-        && !element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)
-    ));
+    // Claim each container synchronously. setup() can be scheduled again while
+    // Splide is loading, so waiting before setting this marker can render the
+    // same slider multiple times.
+    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => {
+        if (element.querySelector(":scope > .editorsChoiceContainer")) {
+            initializedContainers.add(element);
+            element.classList.add(EDITORS_CHOICE_ADDED_CLASS);
+            return false;
+        }
+
+        if (initializingContainers.has(element) || initializedContainers.has(element)) return false;
+        if (element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)) return false;
+
+        initializingContainers.add(element);
+        element.classList.add(EDITORS_CHOICE_LOADING_CLASS);
+        return true;
+    });
     if (!containers.length) return;
 
     try {
         await ensureSplideLoaded();
     } catch (e) {
+        for (const elem of containers) {
+            initializingContainers.delete(elem);
+            elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+        }
         console.warn("Editors Choice: Splide failed to load.", e);
         return;
     }
 
     for (const elem of containers) {
+        if (!elem.isConnected || !elem.matches(HOME_CONTAINER_SELECTOR)) {
+            initializingContainers.delete(elem);
+            elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+            continue;
+        }
+
         console.log("Fetching favourites data from API...");
-        elem.classList.add(EDITORS_CHOICE_LOADING_CLASS);
+        let containerElem;
 
         ApiClient.fetch({ url: ApiClient.getUrl("/EditorsChoice/favourites"), type: "GET" })
             .then((response) => response.json())
             .then((data) => {
+                if (!elem.isConnected || !elem.matches(HOME_CONTAINER_SELECTOR)) return;
+
+                const existingContainer = elem.querySelector(":scope > .editorsChoiceContainer");
+                if (existingContainer) {
+                    initializedContainers.add(elem);
+                    elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
+                    return;
+                }
+
                 if (data.hideOnTvLayout && document.documentElement.classList.contains("layout-tv")) {
                     console.log("Editors Choice: hidden on TV layout by configuration.");
+                    initializedContainers.add(elem);
                     elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
                     return;
                 }
@@ -475,7 +510,7 @@ async function setup() {
                 const template = document.createElement("template");
                 template.innerHTML = container.trim();
                 const content = template.content.cloneNode(true);
-                const containerElem = content.querySelector(".editorsChoiceContainer");
+                containerElem = content.querySelector(".editorsChoiceContainer");
                 const containerId = `editorsChoice-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 
                 containerElem.id = containerId;
@@ -510,8 +545,6 @@ async function setup() {
                     list.insertAdjacentHTML("beforeend", html);
                 }
 
-                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
-
                 // Toggle autoplay control visibility.
                 const playPauseBtn = containerElem.querySelector(".editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
@@ -525,12 +558,20 @@ async function setup() {
                     keyboard: true,
                     height: `${data.bannerHeight + (data.useHeroLayout ? 180 : 0)}px`, // Add 80px to the banner image height in hero mode to compensate for navbar overlay
                 }).mount();
+
+                initializedContainers.add(elem);
+                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
             })
             .catch((e) => {
+                containerElem?.remove();
+                initializedContainers.delete(elem);
                 elem.classList.remove(EDITORS_CHOICE_ADDED_CLASS);
                 console.warn("Editors Choice: failed to fetch/render.", e);
             })
-            .finally(() => elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS));
+            .finally(() => {
+                initializingContainers.delete(elem);
+                elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+            });
     }
 }
 

--- a/EditorsChoicePlugin/EditorsChoicePlugin.csproj
+++ b/EditorsChoicePlugin/EditorsChoicePlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,9 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Common" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Common" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- fixes #81 
- detect the active Jellyfin 12 home container when React mounts it as a nested subtree
- initialize immediately and observe subsequent home-tab mounts and class changes
- debounce setup and prevent duplicate sliders/API requests
- claim home containers before asynchronous Splide loading to prevent concurrent slider injection
- scope hero-mode styling to the active home tab
- replace runtime jQuery usage with native DOM APIs
- target .NET 10 and the final Jellyfin 12.0.0 server packages
- materialize `ILibraryManager.GetItemList` results safely instead of casting Jellyfin 12 arrays to `List<BaseItem>`
- exclude Jellyfin runtime assemblies from the plugin output

## Fixes
- slider initialization failing after Jellyfin 12's nested React home-page mount
- multiple hero sliders being rendered on top of each other during concurrent initialization
- `/EditorsChoice/favourites` returning HTTP 503 because Jellyfin 12 returns item query results as arrays through `IReadOnlyList<BaseItem>`

## Testing
- Release build succeeds with 0 warnings and 0 errors
- browser race test confirms only one slider is rendered during repeated React DOM mutations
- tested successfully on a Jellyfin 12 installation