### PR TITLE
Add automatic frontend injection fallback

### DIFF
--- a/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
+++ b/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
@@ -144,7 +144,7 @@ public class EditorsChoiceActivityController : ControllerBase
                         OrderBy = new[] { (ItemSortBy.Random, SortOrder.Ascending) }
                     };
                     query.Limit = _config.RandomMediaCount * 2;
-                    initialResult = (List<BaseItem>)_libraryManager.GetItemList(query);
+                    initialResult = _libraryManager.GetItemList(query).ToList();
 
                     // Get ids of items in the favourites list
                     List<Guid> itemIds = new List<Guid>();
@@ -259,7 +259,7 @@ public class EditorsChoiceActivityController : ControllerBase
                     OrderBy = new[] { (ItemSortBy.Random, SortOrder.Descending) },
                     IsPlayed = _config.ShowPlayed ? null : false
                 };
-                initialResult = (List<BaseItem>)_libraryManager.GetItemList(queryItems);
+                initialResult = _libraryManager.GetItemList(queryItems).ToList();
 
                 // Of TV series that meet those criteria, loop through to find items that are recent enough. These are already ordered by recency, so can quit on first item that is too old.
                 List<Guid> itemIds = new List<Guid>();
@@ -272,7 +272,7 @@ public class EditorsChoiceActivityController : ControllerBase
                         ParentId = item.Id,
                         OrderBy = new[] { (ItemSortBy.IndexNumber, SortOrder.Descending )}
                     };
-                    List<BaseItem> seasons = (List<BaseItem>) _libraryManager.GetItemList(querySeasons);
+                    List<BaseItem> seasons = _libraryManager.GetItemList(querySeasons).ToList();
 
                     if (seasons.Count > 0) {
                         Guid latestSeasonId = seasons[0].Id;
@@ -285,7 +285,7 @@ public class EditorsChoiceActivityController : ControllerBase
                             ParentId = latestSeasonId,
                             OrderBy = new[] { (ItemSortBy.IndexNumber, SortOrder.Descending) }
                         };
-                        List<BaseItem> episodes = (List<BaseItem>) _libraryManager.GetItemList(queryEpisodes);
+                        List<BaseItem> episodes = _libraryManager.GetItemList(queryEpisodes).ToList();
                         
                         //_logger.LogInformation("Contains {0} episodes.", episodes.Count);
 
@@ -319,7 +319,7 @@ public class EditorsChoiceActivityController : ControllerBase
                     IsPlayed = _config.ShowPlayed ? null : false
                 };
                 queryMovies.Limit = _config.RandomMediaCount;
-                List<BaseItem> resultMovies = (List<BaseItem>) _libraryManager.GetItemList(queryMovies);
+                List<BaseItem> resultMovies = _libraryManager.GetItemList(queryMovies).ToList();
 
                 // Join the lists of recent films and recent series
                 foreach (BaseItem item in resultMovies) itemIds.Add(item.Id);
@@ -411,15 +411,15 @@ public class EditorsChoiceActivityController : ControllerBase
         }
         catch (Exception e)
         {
-            _logger.LogError(e.ToString());
-            return StatusCode(503);
+            _logger.LogError(e, "Failed to build the Editors Choice response.");
+            return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
     }
 
     private List<BaseItem> PrepareResult(InternalItemsQuery query, Jellyfin.Database.Implementations.Entities.User? activeUser)
     {
-        List<BaseItem> initialResult = (List<BaseItem>)_libraryManager.GetItemList(query);
+        List<BaseItem> initialResult = _libraryManager.GetItemList(query).ToList();
         List<BaseItem> result = [];
 
         // Randomly add items until we run out or reach the admin-set cap

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -8,7 +8,7 @@ const container = `
           <span class="material-icons chevron_left" aria-hidden="true"></span>
         </button>
 
-        <button class="splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button" id="editorsChoicePlayPause">
+        <button class="editorsChoicePlayPause splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button">
           <span class="splide__toggle__play material-icons play_arrow" aria-hidden="true"></span>
           <span class="splide__toggle__pause material-icons pause" aria-hidden="true"></span>
         </button>
@@ -184,7 +184,7 @@ const container = `
 
   /* ===== Hero mode ===== */
   .editorsChoiceHeroMode .editorsChoiceContainer { padding: 0 !important; }
-  .editorsChoiceHeroMode #homeTab { transform: translateY(-120px); }
+  #homeTab.editorsChoiceHeroMode { transform: translateY(-120px); }
 
   .editorsChoiceHeroMode .splide.cardScalable {
     border-radius: unset !important;
@@ -278,6 +278,9 @@ const container = `
 `;
 
 const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
+const HOME_CONTAINER_SELECTOR = "#indexPage:not(.hide) #homeTab.is-active .homeSectionsContainer";
+const EDITORS_CHOICE_ADDED_CLASS = "editorsChoiceAdded";
+const EDITORS_CHOICE_LOADING_CLASS = "editorsChoiceLoading";
 
 /* ===== Utils ===== */
 function shuffle(input) {
@@ -442,8 +445,11 @@ function renderNormalSlide(item, data, baseUrl) {
 async function setup() {
     console.log("Attempting creation of editors choice slider.");
 
-    const $containers = $(".homeSectionsContainer").filter((_, el) => !$(el).hasClass("editorsChoiceAdded"));
-    if (!$containers.length) return;
+    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => (
+        !element.classList.contains(EDITORS_CHOICE_ADDED_CLASS)
+        && !element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)
+    ));
+    if (!containers.length) return;
 
     try {
         await ensureSplideLoaded();
@@ -452,57 +458,65 @@ async function setup() {
         return;
     }
 
-    $containers.each((_, elem) => {
+    for (const elem of containers) {
         console.log("Fetching favourites data from API...");
+        elem.classList.add(EDITORS_CHOICE_LOADING_CLASS);
 
         ApiClient.fetch({ url: ApiClient.getUrl("/EditorsChoice/favourites"), type: "GET" })
             .then((response) => response.json())
             .then((data) => {
                 if (data.hideOnTvLayout && document.documentElement.classList.contains("layout-tv")) {
                     console.log("Editors Choice: hidden on TV layout by configuration.");
+                    elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
                     return;
                 }
 
                 const favourites = shuffle(data.favourites || []);
-                const $containerElem = $(container);
+                const template = document.createElement("template");
+                template.innerHTML = container.trim();
+                const content = template.content.cloneNode(true);
+                const containerElem = content.querySelector(".editorsChoiceContainer");
                 const containerId = `editorsChoice-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 
-                $containerElem.first().attr("id", containerId);
-                $containerElem.first().addClass(`editorsChoiceHeight-${data.bannerHeight}`);
-                $(elem).prepend($containerElem);
+                containerElem.id = containerId;
+                containerElem.classList.add(`editorsChoiceHeight-${data.bannerHeight}`);
+                elem.prepend(content);
 
                 // TV focus workaround
                 let focusResolved = false;
-                $(`.layout-tv #${containerId} .emby-scrollbuttons button`).on("focus", function () {
-                    if (focusResolved) return;
-                    $('[is="emby-tabs"] .emby-button').first().trigger("focus");
-                    focusResolved = true;
+                containerElem.querySelectorAll(".emby-scrollbuttons button").forEach((button) => {
+                    button.addEventListener("focus", () => {
+                        if (focusResolved || !document.documentElement.classList.contains("layout-tv")) return;
+                        document.querySelector('[is="emby-tabs"] .emby-button')?.focus();
+                        focusResolved = true;
+                    });
                 });
 
-                if (data.useHeroLayout) document.body.classList.add("editorsChoiceHeroMode");
+                const homeTab = elem.closest("#homeTab");
+                if (homeTab) homeTab.classList.toggle("editorsChoiceHeroMode", !!data.useHeroLayout);
 
                 if ("heading" in data && data.heading && !data.useHeroLayout) {
-                    $($containerElem).prepend(`<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
+                    containerElem.insertAdjacentHTML("afterbegin", `<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
                 }
 
                 const baseUrl = getBaseUrl();
-                const $list = $(`#${containerId} .editorsChoiceItemsContainer`);
+                const list = containerElem.querySelector(".editorsChoiceItemsContainer");
 
                 for (const item of favourites) {
                     const html = data.useHeroLayout
                         ? renderHeroSlide(item, data, baseUrl)
                         : renderNormalSlide(item, data, baseUrl);
 
-                    $list.append(html);
+                    list.insertAdjacentHTML("beforeend", html);
                 }
 
-                $(elem).addClass("editorsChoiceAdded");
+                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
 
-                // Toggle autoplay control visibility (button exists: #editorsChoicePlayPause)
-                const playPauseBtn = document.getElementById("editorsChoicePlayPause");
+                // Toggle autoplay control visibility.
+                const playPauseBtn = containerElem.querySelector(".editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
 
-                new Splide(`#${containerId} .splide`, {
+                new Splide(containerElem.querySelector(".splide"), {
                     type: data.transitionEffect ?? "loop",
                     autoplay: !!data.autoplay,
                     rewind: true,
@@ -512,37 +526,76 @@ async function setup() {
                     height: `${data.bannerHeight + (data.useHeroLayout ? 180 : 0)}px`, // Add 80px to the banner image height in hero mode to compensate for navbar overlay
                 }).mount();
             })
-            .catch((e) => console.warn("Editors Choice: failed to fetch/render.", e));
+            .catch((e) => {
+                elem.classList.remove(EDITORS_CHOICE_ADDED_CLASS);
+                console.warn("Editors Choice: failed to fetch/render.", e);
+            })
+            .finally(() => elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS));
+    }
+}
+
+let setupScheduled = false;
+
+function scheduleSetup() {
+    if (setupScheduled) return;
+
+    setupScheduled = true;
+    window.requestAnimationFrame(() => {
+        setupScheduled = false;
+        setup();
     });
 }
 
-window.onload = function () {
-    // Detect if container is ready to setup slider
-    const target = document.getElementById("reactRoot");
+function nodeContainsHomeContainer(node) {
+    if (!(node instanceof Element)) return false;
+
+    return node.matches(HOME_CONTAINER_SELECTOR)
+        || !!node.querySelector(HOME_CONTAINER_SELECTOR)
+        || !!node.closest(HOME_CONTAINER_SELECTOR);
+}
+
+function initializeEditorsChoice() {
+    // Jellyfin 12 mounts the legacy home tab as a nested React subtree. Observe
+    // the React root when available and fall back to body for older web clients.
+    const target = document.getElementById("reactRoot") || document.body;
     if (!target) {
-        console.warn("Editors Choice: reactRoot not found.");
+        console.warn("Editors Choice: page root not found.");
         return;
     }
 
     const observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
-            const newNodes = mutation.addedNodes;
-            if (!newNodes || !newNodes.length) continue;
-
-            $(newNodes).each(function () {
-                const $node = $(this);
-                if ($node.hasClass("section0") && !$node.hasClass("editorsChoiceAdded")) {
-                    setup();
+            if (mutation.type === "attributes") {
+                const element = mutation.target;
+                if (element instanceof Element && element.matches("#indexPage, #homeTab")) {
+                    scheduleSetup();
+                    return;
                 }
-            });
+            }
+
+            for (const node of mutation.addedNodes) {
+                if (nodeContainsHomeContainer(node)) {
+                    scheduleSetup();
+                    return;
+                }
+            }
         }
     });
 
-    observer.observe(target, { attributes: true, childList: true, characterData: true, subtree: true });
+    observer.observe(target, {
+        attributes: true,
+        attributeFilter: ["class"],
+        childList: true,
+        subtree: true,
+    });
+
+    // The script can be loaded after the home tab has already mounted.
+    scheduleSetup();
 
     // Remind user that their favourites will be public when they add a new favourite.
-    $("body").on("click", '[is="emby-ratingbutton"]', function () {
-        if ($(this).hasClass("ratingbutton-withrating")) return;
+    document.body.addEventListener("click", (event) => {
+        const ratingButton = event.target.closest?.('[is="emby-ratingbutton"]');
+        if (!ratingButton || ratingButton.classList.contains("ratingbutton-withrating")) return;
 
         ApiClient.getPluginConfiguration(GUID).then((data) => {
             if (ApiClient.getCurrentUserId() === data.EditorUserId) {
@@ -550,4 +603,10 @@ window.onload = function () {
             }
         });
     });
-};
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeEditorsChoice, { once: true });
+} else {
+    initializeEditorsChoice();
+}

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -281,6 +281,8 @@ const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
 const HOME_CONTAINER_SELECTOR = "#indexPage:not(.hide) #homeTab.is-active .homeSectionsContainer";
 const EDITORS_CHOICE_ADDED_CLASS = "editorsChoiceAdded";
 const EDITORS_CHOICE_LOADING_CLASS = "editorsChoiceLoading";
+const initializingContainers = new WeakSet();
+const initializedContainers = new WeakSet();
 
 /* ===== Utils ===== */
 function shuffle(input) {
@@ -445,28 +447,61 @@ function renderNormalSlide(item, data, baseUrl) {
 async function setup() {
     console.log("Attempting creation of editors choice slider.");
 
-    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => (
-        !element.classList.contains(EDITORS_CHOICE_ADDED_CLASS)
-        && !element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)
-    ));
+    // Claim each container synchronously. setup() can be scheduled again while
+    // Splide is loading, so waiting before setting this marker can render the
+    // same slider multiple times.
+    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => {
+        if (element.querySelector(":scope > .editorsChoiceContainer")) {
+            initializedContainers.add(element);
+            element.classList.add(EDITORS_CHOICE_ADDED_CLASS);
+            return false;
+        }
+
+        if (initializingContainers.has(element) || initializedContainers.has(element)) return false;
+        if (element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)) return false;
+
+        initializingContainers.add(element);
+        element.classList.add(EDITORS_CHOICE_LOADING_CLASS);
+        return true;
+    });
     if (!containers.length) return;
 
     try {
         await ensureSplideLoaded();
     } catch (e) {
+        for (const elem of containers) {
+            initializingContainers.delete(elem);
+            elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+        }
         console.warn("Editors Choice: Splide failed to load.", e);
         return;
     }
 
     for (const elem of containers) {
+        if (!elem.isConnected || !elem.matches(HOME_CONTAINER_SELECTOR)) {
+            initializingContainers.delete(elem);
+            elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+            continue;
+        }
+
         console.log("Fetching favourites data from API...");
-        elem.classList.add(EDITORS_CHOICE_LOADING_CLASS);
+        let containerElem;
 
         ApiClient.fetch({ url: ApiClient.getUrl("/EditorsChoice/favourites"), type: "GET" })
             .then((response) => response.json())
             .then((data) => {
+                if (!elem.isConnected || !elem.matches(HOME_CONTAINER_SELECTOR)) return;
+
+                const existingContainer = elem.querySelector(":scope > .editorsChoiceContainer");
+                if (existingContainer) {
+                    initializedContainers.add(elem);
+                    elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
+                    return;
+                }
+
                 if (data.hideOnTvLayout && document.documentElement.classList.contains("layout-tv")) {
                     console.log("Editors Choice: hidden on TV layout by configuration.");
+                    initializedContainers.add(elem);
                     elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
                     return;
                 }
@@ -475,7 +510,7 @@ async function setup() {
                 const template = document.createElement("template");
                 template.innerHTML = container.trim();
                 const content = template.content.cloneNode(true);
-                const containerElem = content.querySelector(".editorsChoiceContainer");
+                containerElem = content.querySelector(".editorsChoiceContainer");
                 const containerId = `editorsChoice-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 
                 containerElem.id = containerId;
@@ -510,8 +545,6 @@ async function setup() {
                     list.insertAdjacentHTML("beforeend", html);
                 }
 
-                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
-
                 // Toggle autoplay control visibility.
                 const playPauseBtn = containerElem.querySelector(".editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
@@ -525,12 +558,20 @@ async function setup() {
                     keyboard: true,
                     height: `${data.bannerHeight + (data.useHeroLayout ? 180 : 0)}px`, // Add 80px to the banner image height in hero mode to compensate for navbar overlay
                 }).mount();
+
+                initializedContainers.add(elem);
+                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
             })
             .catch((e) => {
+                containerElem?.remove();
+                initializedContainers.delete(elem);
                 elem.classList.remove(EDITORS_CHOICE_ADDED_CLASS);
                 console.warn("Editors Choice: failed to fetch/render.", e);
             })
-            .finally(() => elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS));
+            .finally(() => {
+                initializingContainers.delete(elem);
+                elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+            });
     }
 }
 

--- a/EditorsChoicePlugin/Configuration/FrontendInjectionMethods.cs
+++ b/EditorsChoicePlugin/Configuration/FrontendInjectionMethods.cs
@@ -1,0 +1,26 @@
+namespace EditorsChoicePlugin.Configuration;
+
+public static class FrontendInjectionMethods
+{
+    public const string Automatic = "automatic";
+
+    public const string FileTransformation = "file-transformation";
+
+    public const string JavaScriptInjector = "javascript-injector";
+
+    public const string Direct = "direct";
+
+    public const string Disabled = "disabled";
+
+    public static string Normalize(string? value)
+    {
+        return value switch
+        {
+            FileTransformation => FileTransformation,
+            JavaScriptInjector => JavaScriptInjector,
+            Direct => Direct,
+            Disabled => Disabled,
+            _ => Automatic
+        };
+    }
+}

--- a/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
+++ b/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
@@ -8,8 +8,12 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string EditorUserId { get; set; } = "";
 
+    public string FrontendInjectionMethod { get; set; } = FrontendInjectionMethods.Automatic;
+
+    // Retained for configuration compatibility with older plugin releases.
     public bool DoScriptInject { get; set; } = true;
 
+    // Retained for configuration compatibility with older plugin releases.
     public bool FileTransformation { get; set; } = false;
 
     public bool ShowRandomMedia { get; set; } = true;

--- a/EditorsChoicePlugin/Configuration/configPage.html
+++ b/EditorsChoicePlugin/Configuration/configPage.html
@@ -372,22 +372,17 @@
                     <hr />
                     <h2>Technical settings</h2>
 
-                    <div class="checkboxContainer checkboxContainer-withDescription">
-                        <label class="emby-checkbox-label">
-                            <input is="emby-checkbox" type="checkbox" id="DoScriptInject" name="DoScriptInject" />
-                            <span class="checkboxLabel">Enable client script injection</span>
-                        </label>
-                        <div class="fieldDescription">This will depend on permissions for the jellyfin-web index.html file. Toggling this mode will take effect after the next restart.</div>
-                    </div>
-
-                    <div class="checkboxContainer checkboxContainer-withDescription">
-                        <label class="emby-checkbox-label">
-                            <input is="emby-checkbox" type="checkbox" id="FileTransformation" name="FileTransformation" />
-                            <span class="checkboxLabel">Use FileTransformation plugin (recommended)</span>
-                        </label>
+                    <div class="selectContainer">
+                        <label class="selectLabel" for="FrontendInjectionMethod">Frontend injection method:</label>
+                        <select is="emby-select" id="FrontendInjectionMethod" name="FrontendInjectionMethod" class="emby-select-withcolor emby-select">
+                            <option value="automatic">Automatic (recommended)</option>
+                            <option value="file-transformation">File Transformation only</option>
+                            <option value="javascript-injector">JavaScript Injector only</option>
+                            <option value="direct">Direct index.html injection only</option>
+                            <option value="disabled">Disabled / manual injection</option>
+                        </select>
                         <div class="fieldDescription">
-                            Using <a href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank" rel="noopener noreferrer">the FileTransformation plugin</a>
-                            is the easiest way to inject the required script to the Jellyfin homepage. Toggling this mode will take effect after the next restart.
+                            Automatic prefers File Transformation, then JavaScript Injector, and only writes directly to jellyfin-web/index.html as a final fallback. Changes take effect after the next restart.
                         </div>
                     </div>
 
@@ -426,8 +421,7 @@
                     ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                         selectedUserId = config.EditorUserId;
                         //$('#EditorUserId').first().val(config.EditorUserId);
-                        $('#DoScriptInject').first().prop('checked', config.DoScriptInject);
-                        $('#FileTransformation').first().prop('checked', config.FileTransformation);
+                        $('#FrontendInjectionMethod').val(config.FrontendInjectionMethod || 'automatic');
                         $('#ShowRandomMedia').first().prop('checked', config.ShowRandomMedia);
                         $('#FavouritesMode').first().prop('checked', config.Mode == 'FAVOURITES');
                         $('#RandomMode').first().prop('checked', config.Mode == 'RANDOM');
@@ -576,8 +570,10 @@
                             config.EditorUserId = $('#EditorUserId').first().val();
                         }
 
-                        config.DoScriptInject = $('#DoScriptInject').first().is(':checked');
-                        config.FileTransformation = $('#FileTransformation').first().is(':checked');
+                        config.FrontendInjectionMethod = $('#FrontendInjectionMethod').val();
+                        // Keep legacy settings useful if an older Editors Choice build is restored.
+                        config.DoScriptInject = config.FrontendInjectionMethod == 'automatic' || config.FrontendInjectionMethod == 'direct';
+                        config.FileTransformation = config.FrontendInjectionMethod == 'file-transformation';
                         config.EnableAutoplay = $('#EnableAutoplay').first().is(':checked');
                         config.AutoplayInterval = $('#AutoplayInterval').first().val();
                         config.ShowRating = $('#ShowRating').first().is(':checked');
@@ -660,20 +656,6 @@
                     $('#NewTimeLimit-container').toggle($('#NewMode').is(':checked'));
                     $('#AutoplayInterval-container').toggle($('#EnableAutoplay').is(':checked'));
                 });
-
-
-                // If user chooses scriptinject or filetransformation, disable the other.
-                $('#DoScriptInject').on('change', function () {
-                    if ($(this).is(':checked')) {
-                        $('#FileTransformation').first().prop('checked', false);
-                    }
-                })
-
-                $('#FileTransformation').on('change', function () {
-                    if ($(this).is(':checked')) {
-                        $('#DoScriptInject').first().prop('checked', false);
-                    }
-                })
 
             })();
 

--- a/EditorsChoicePlugin/EditorsChoicePlugin.csproj
+++ b/EditorsChoicePlugin/EditorsChoicePlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,9 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Common" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Common" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/EditorsChoicePlugin/Helpers/DirectScriptInjector.cs
+++ b/EditorsChoicePlugin/Helpers/DirectScriptInjector.cs
@@ -1,0 +1,70 @@
+using System.Text.RegularExpressions;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace EditorsChoicePlugin.Helpers;
+
+public static class DirectScriptInjector
+{
+    public static bool TryInject(IApplicationPaths applicationPaths, string basePath, ILogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(applicationPaths.WebPath))
+        {
+            logger.LogWarning("Jellyfin web path is unavailable; direct Editors Choice injection cannot be used.");
+            return false;
+        }
+
+        string indexFile = Path.Combine(applicationPaths.WebPath, "index.html");
+
+        try
+        {
+            if (!File.Exists(indexFile))
+            {
+                logger.LogWarning("Jellyfin web index was not found at {IndexFile}.", indexFile);
+                return false;
+            }
+
+            string scriptElement = ScriptMarkup.Build(basePath, "injection=\"true\"");
+            string indexContents = File.ReadAllText(indexFile);
+            if (indexContents.Contains(scriptElement, StringComparison.Ordinal))
+            {
+                logger.LogInformation("Found Editors Choice client script in {IndexFile}.", indexFile);
+                return true;
+            }
+
+            indexContents = ScriptMarkup.RemoveExisting(indexContents);
+            int bodyClosing = indexContents.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
+            if (bodyClosing < 0)
+            {
+                logger.LogWarning("Could not find a closing body tag in {IndexFile}.", indexFile);
+                return false;
+            }
+
+            indexContents = indexContents.Insert(bodyClosing, scriptElement);
+            File.WriteAllText(indexFile, indexContents);
+            logger.LogInformation("Injected Editors Choice client script into {IndexFile}.", indexFile);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to inject Editors Choice client script into {IndexFile}.", indexFile);
+            return false;
+        }
+    }
+}
+
+public static partial class ScriptMarkup
+{
+    [GeneratedRegex("<script\\b(?=[^>]*\\bplugin=([\"'])EditorsChoice\\1)[^>]*>\\s*</script>", RegexOptions.IgnoreCase)]
+    private static partial Regex ExistingScriptRegex();
+
+    public static string Build(string basePath, string markerAttribute)
+    {
+        return $"<script {markerAttribute} plugin=\"EditorsChoice\" defer=\"defer\" src=\"{basePath}/EditorsChoice/script\"></script>";
+    }
+
+    public static string RemoveExisting(string contents)
+    {
+        return ExistingScriptRegex().Replace(contents, string.Empty);
+    }
+}

--- a/EditorsChoicePlugin/Helpers/FileTransformationRegistrar.cs
+++ b/EditorsChoicePlugin/Helpers/FileTransformationRegistrar.cs
@@ -1,0 +1,61 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace EditorsChoicePlugin.Helpers;
+
+public static class FileTransformationRegistrar
+{
+    private const string PluginInterfaceTypeName = "Jellyfin.Plugin.FileTransformation.PluginInterface";
+    private const string TransformationId = "b3d45a0e-3dac-4413-97df-32a13316571e";
+
+    public static bool TryRegister(ILogger logger)
+    {
+        try
+        {
+            Assembly? assembly = AssemblyLoadContext.All
+                .SelectMany(context => context.Assemblies)
+                .FirstOrDefault(candidate =>
+                    candidate.FullName?.Contains(".FileTransformation", StringComparison.OrdinalIgnoreCase) ?? false);
+
+            if (assembly is null)
+            {
+                logger.LogDebug("File Transformation plugin was not found.");
+                return false;
+            }
+
+            Type? pluginInterfaceType = assembly.GetType(PluginInterfaceTypeName);
+            MethodInfo? registerMethod = pluginInterfaceType?.GetMethod("RegisterTransformation");
+            if (registerMethod is null)
+            {
+                logger.LogWarning("File Transformation registration interface was not found.");
+                return false;
+            }
+
+            JObject payload = new JObject
+            {
+                { "id", TransformationId },
+                { "fileNamePattern", "index.html" },
+                { "callbackAssembly", typeof(FileTransformationRegistrar).Assembly.FullName },
+                { "callbackClass", typeof(Transformations).FullName },
+                { "callbackMethod", nameof(Transformations.IndexTransformation) }
+            };
+
+            object? result = registerMethod.Invoke(null, new object?[] { payload });
+            if (result is false)
+            {
+                logger.LogWarning("File Transformation rejected the Editors Choice registration.");
+                return false;
+            }
+
+            logger.LogInformation("Editors Choice registered with File Transformation.");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to register Editors Choice with File Transformation.");
+            return false;
+        }
+    }
+}

--- a/EditorsChoicePlugin/Helpers/FrontendRegistration.cs
+++ b/EditorsChoicePlugin/Helpers/FrontendRegistration.cs
@@ -1,0 +1,48 @@
+using EditorsChoicePlugin.Configuration;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace EditorsChoicePlugin.Helpers;
+
+public static class FrontendRegistration
+{
+    public static bool TryRegisterConfigured(
+        PluginConfiguration configuration,
+        IApplicationPaths applicationPaths,
+        string basePath,
+        ILogger logger)
+    {
+        string method = FrontendInjectionMethods.Normalize(configuration.FrontendInjectionMethod);
+
+        switch (method)
+        {
+            case FrontendInjectionMethods.FileTransformation:
+                return FileTransformationRegistrar.TryRegister(logger);
+
+            case FrontendInjectionMethods.JavaScriptInjector:
+                return JavaScriptInjectorRegistrar.TryRegister(basePath, logger);
+
+            case FrontendInjectionMethods.Direct:
+                return DirectScriptInjector.TryInject(applicationPaths, basePath, logger);
+
+            case FrontendInjectionMethods.Disabled:
+                logger.LogInformation("Editors Choice frontend injection is disabled.");
+                return true;
+
+            default:
+                if (FileTransformationRegistrar.TryRegister(logger))
+                {
+                    return true;
+                }
+
+                if (JavaScriptInjectorRegistrar.TryRegister(basePath, logger))
+                {
+                    return true;
+                }
+
+                logger.LogInformation(
+                    "Neither File Transformation nor JavaScript Injector was available. Falling back to direct index.html injection.");
+                return DirectScriptInjector.TryInject(applicationPaths, basePath, logger);
+        }
+    }
+}

--- a/EditorsChoicePlugin/Helpers/JavaScriptInjectorRegistrar.cs
+++ b/EditorsChoicePlugin/Helpers/JavaScriptInjectorRegistrar.cs
@@ -1,0 +1,94 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace EditorsChoicePlugin.Helpers;
+
+public static class JavaScriptInjectorRegistrar
+{
+    private const string AssemblyName = "Jellyfin.Plugin.JavaScriptInjector";
+    private const string PluginInterfaceTypeName = "Jellyfin.Plugin.JavaScriptInjector.PluginInterface";
+    private const string ScriptId = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae-editors-choice";
+
+    public static bool TryRegister(string basePath, ILogger logger)
+    {
+        try
+        {
+            Plugin? plugin = Plugin.Instance;
+            if (plugin is null)
+            {
+                logger.LogWarning("Editors Choice plugin instance was not available for JavaScript Injector registration.");
+                return false;
+            }
+
+            Assembly? assembly = AssemblyLoadContext.All
+                .SelectMany(context => context.Assemblies)
+                .FirstOrDefault(candidate =>
+                    candidate.FullName?.Contains(AssemblyName, StringComparison.OrdinalIgnoreCase) ?? false);
+
+            if (assembly is null)
+            {
+                logger.LogDebug("JavaScript Injector plugin was not found.");
+                return false;
+            }
+
+            Type? pluginInterfaceType = assembly.GetType(PluginInterfaceTypeName);
+            MethodInfo? registerMethod = pluginInterfaceType?.GetMethod("RegisterScript");
+            if (registerMethod is null)
+            {
+                logger.LogWarning("JavaScript Injector registration interface was not found.");
+                return false;
+            }
+
+            JObject payload = new JObject
+            {
+                { "id", ScriptId },
+                { "name", "Editors Choice loader" },
+                { "script", BuildLoaderScript(basePath) },
+                { "enabled", true },
+                { "requiresAuthentication", false },
+                { "pluginId", plugin.Id.ToString() },
+                { "pluginName", plugin.Name },
+                { "pluginVersion", typeof(JavaScriptInjectorRegistrar).Assembly.GetName().Version?.ToString() ?? string.Empty }
+            };
+
+            object? result = registerMethod.Invoke(null, new object?[] { payload });
+            if (result is not true)
+            {
+                logger.LogWarning("JavaScript Injector rejected the Editors Choice registration.");
+                return false;
+            }
+
+            logger.LogInformation("Editors Choice registered with JavaScript Injector.");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to register Editors Choice with JavaScript Injector.");
+            return false;
+        }
+    }
+
+    public static string BuildLoaderScript(string basePath)
+    {
+        string scriptUrl = JsonConvert.SerializeObject($"{basePath}/EditorsChoice/script");
+
+        return $$"""
+            (() => {
+                'use strict';
+
+                if (document.querySelector('script[plugin="EditorsChoice"], script[data-plugin="EditorsChoice"]')) {
+                    return;
+                }
+
+                const script = document.createElement('script');
+                script.defer = true;
+                script.dataset.plugin = 'EditorsChoice';
+                script.src = {{scriptUrl}};
+                (document.head || document.documentElement).appendChild(script);
+            })();
+            """;
+    }
+}

--- a/EditorsChoicePlugin/Helpers/Transformations.cs
+++ b/EditorsChoicePlugin/Helpers/Transformations.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 using MediaBrowser.Common.Net;
 
 namespace EditorsChoicePlugin.Helpers;
@@ -16,11 +15,11 @@ public static class Transformations
             basePath = $"/{networkConfiguration.BaseUrl.TrimStart('/').Trim()}";
         }
 
-        string script = $"<script FileTransformation=\"true\" plugin=\"EditorsChoice\" defer=\"defer\" src=\"{basePath}/EditorsChoice/script\"></script>";
+        string contents = ScriptMarkup.RemoveExisting(payload.Contents ?? string.Empty);
+        string script = ScriptMarkup.Build(basePath, "FileTransformation=\"true\"");
+        int bodyClosing = contents.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
 
-        string text = Regex.Replace(payload.Contents!, "(</body>)", $"{script}$1");
-
-        return text;
+        return bodyClosing < 0 ? contents : contents.Insert(bodyClosing, script);
     }
 }
 

--- a/EditorsChoicePlugin/StartupService.cs
+++ b/EditorsChoicePlugin/StartupService.cs
@@ -1,185 +1,78 @@
 using EditorsChoicePlugin.Configuration;
-using MediaBrowser.Controller;
-using MediaBrowser.Controller.Library;
+using EditorsChoicePlugin.Helpers;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Net;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
-using MediaBrowser.Common.Configuration;
-using System.Text.RegularExpressions;
-using MediaBrowser.Common.Net;
-using System.Reflection;
-using System.Runtime.Loader;
-using Newtonsoft.Json.Linq;
-using EditorsChoicePlugin.Helpers;
 
 namespace EditorsChoicePlugin;
+
 public class StartupService : IScheduledTask
 {
+    private readonly ILogger<Plugin> _logger;
+    private readonly IApplicationPaths _applicationPaths;
+    private readonly PluginConfiguration _config;
+
+    public StartupService(ILogger<Plugin> logger, IApplicationPaths applicationPaths)
+    {
+        _logger = logger;
+        _applicationPaths = applicationPaths;
+        _config = Plugin.Instance!.Configuration;
+    }
+
     public string Name => "EditorsChoice Startup";
 
     public string Key => "Jellyfin.Plugin.EditorsChoice.Startup";
-    
-    public string Description => "Startup Service for Editors choice";
-    
-    public string Category => "Startup Services";
-    
-    private readonly IServerApplicationHost _serverApplicationHost;
-    private readonly ILogger<Plugin> _logger;
-    private readonly IUserManager _userManager;
-    private readonly IApplicationPaths _applicationPaths;
-    private readonly IServerApplicationHost _applicationHost;
-    private readonly IConfigurationManager _configurationManager;
-    private readonly PluginConfiguration _config;
-    private String _basePath;
 
-    public StartupService(IServerApplicationHost serverApplicationHost, ILogger<Plugin> logger, IUserManager userManager, IApplicationPaths applicationPaths, IServerApplicationHost applicationHost, IConfigurationManager configurationManager)
-    {
-        _serverApplicationHost = serverApplicationHost;
-        _logger = logger;
-        _userManager = userManager;
-        _applicationPaths = applicationPaths;
-        _applicationHost = applicationHost;
-        _configurationManager = configurationManager;
-        _config = Plugin.Instance!.Configuration;
-        _basePath = "";
-    }
+    public string Description => "Registers the Editors Choice frontend script.";
+
+    public string Category => "Startup Services";
 
     public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        _logger.LogInformation($"EditorsChoice Startup. Registering file transformations.");
+        _logger.LogInformation("Editors Choice startup: registering the frontend script.");
 
-        
-        
-        // Convert configuration mode boolean variable
-        if (_config.Mode == "")
+        if (string.IsNullOrEmpty(_config.Mode))
         {
-            if (_config.ShowRandomMedia)
-            {
-                _config.Mode = "RANDOM";
-            }
-            else
-            {
-                _config.Mode = "FAVOURITES";
-            }
+            _config.Mode = _config.ShowRandomMedia ? "RANDOM" : "FAVOURITES";
         }
 
-        // Get base path from network config
-        try
+        string basePath = GetBasePath();
+        if (!FrontendRegistration.TryRegisterConfigured(_config, _applicationPaths, basePath, _logger))
         {
-            NetworkConfiguration networkConfiguration = Plugin.Instance!.ServerConfigurationManager.GetNetworkConfiguration();
-
-            string basePath = "";
-            if (!string.IsNullOrWhiteSpace(networkConfiguration.BaseUrl))
-            {
-                basePath = $"/{networkConfiguration.BaseUrl.TrimStart('/').Trim()}";
-            }
-
-            if (!string.IsNullOrEmpty(basePath))
-            {
-                _basePath = basePath.ToString();
-                _logger.LogInformation($"BasePath is {_basePath}");
-            }
-        }
-        catch (Exception e)
-        {
-            _logger.LogError("Unable to get base path from config, using '/': {e}", e);
-        }
-
-        // https://github.com/nicknsy/jellyscrub/blob/main/Nick.Plugin.Jellyscrub/JellyscrubPlugin.cs
-        if (_config.DoScriptInject)
-        {
-            if (!string.IsNullOrWhiteSpace(_applicationPaths.WebPath))
-            {
-                var indexFile = Path.Combine(_applicationPaths.WebPath, "index.html");
-                if (File.Exists(indexFile))
-                {
-                    string indexContents = File.ReadAllText(indexFile);
-
-
-                    // Don't run if script already exists, unless it's a variation.
-                    string scriptReplace = "<script plugin=\"EditorsChoice\".*?></script>(<style plugin=\"EditorsChoice\">.*?</style>)?";
-                    string scriptElement = string.Format("<script injection=\"true\" plugin=\"EditorsChoice\" defer=\"defer\" src=\"{0}/EditorsChoice/script\"></script>", _basePath);
-
-                    if (!indexContents.Contains(scriptElement))
-                    {
-                        _logger.LogInformation("Attempting to inject editorschoice client script code in {indexFile}", indexFile);
-
-                        // Replace old scripts
-                        indexContents = Regex.Replace(indexContents, scriptReplace, "");
-
-                        // Insert script last in body
-                        int bodyClosing = indexContents.LastIndexOf("</body>");
-                        if (bodyClosing != -1)
-                        {
-                            indexContents = indexContents.Insert(bodyClosing, scriptElement);
-
-                            try
-                            {
-                                File.WriteAllText(indexFile, indexContents);
-                                _logger.LogInformation("Finished injecting EditorsChoice script code in {indexFile}", indexFile);
-                            }
-                            catch (Exception e)
-                            {
-                                _logger.LogError("Encountered exception while writing to {indexFile}: {e}", indexFile, e);
-                            }
-                        }
-                        else
-                        {
-                            _logger.LogInformation("Could not find closing body tag in {indexFile}", indexFile);
-                        }
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Found client script injected in {indexFile}", indexFile);
-                    }
-                }
-            }
-        }
-        else if (_config.FileTransformation)
-        {
-            _ = RegisterTransformation();
+            _logger.LogWarning(
+                "Editors Choice could not register its frontend script using method {InjectionMethod}.",
+                FrontendInjectionMethods.Normalize(_config.FrontendInjectionMethod));
         }
 
         return Task.CompletedTask;
     }
 
-    public Task RegisterTransformation()
-    {
-        try
-        {
-            JObject data = new JObject
-            {
-                { "id", "b3d45a0e-3dac-4413-97df-32a13316571e" },
-                { "fileNamePattern", "index.html" },
-                { "callbackAssembly", GetType().Assembly.FullName },
-                { "callbackClass", typeof(Transformations).FullName },
-                { "callbackMethod", nameof(Transformations.IndexTransformation)}
-            };
-
-            Assembly? fileTransformationAssembly = AssemblyLoadContext.All.SelectMany(x => x.Assemblies).FirstOrDefault(x => x.FullName?.Contains(".FileTransformation") ?? false);
-
-            if (fileTransformationAssembly != null)
-            {
-                Type? pluginInterfaceType = fileTransformationAssembly.GetType("Jellyfin.Plugin.FileTransformation.PluginInterface");
-                if (pluginInterfaceType != null)
-                {
-                    pluginInterfaceType.GetMethod("RegisterTransformation")?.Invoke(null, new object?[] { data });
-                }
-            }
-
-            return Task.CompletedTask;
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e.ToString());
-            return Task.CompletedTask;
-        }
-    }
-
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
     {
-        yield return new TaskTriggerInfo()
+        yield return new TaskTriggerInfo
         {
             Type = TaskTriggerInfoType.StartupTrigger
         };
+    }
+
+    private string GetBasePath()
+    {
+        try
+        {
+            NetworkConfiguration networkConfiguration = Plugin.Instance!.ServerConfigurationManager.GetNetworkConfiguration();
+            if (!string.IsNullOrWhiteSpace(networkConfiguration.BaseUrl))
+            {
+                string basePath = $"/{networkConfiguration.BaseUrl.Trim().Trim('/')}";
+                _logger.LogInformation("Editors Choice base path is {BasePath}.", basePath);
+                return basePath;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unable to get the Jellyfin base path; using '/'.");
+        }
+
+        return string.Empty;
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,38 +14,51 @@ The featured content list is drawn from a specified user's favourited items, or 
 Note that the plugin only works for the web UI (and therefore also the mobile app), but does not and can not work for the Android TV app or other apps due to limitations of those platforms.
 
 ## Installation
-There are three ways to install this plugin.
+There are four ways to install this plugin.
 
 The first step is to install this plugin by adding the repository:
 
 1. Add `https://github.com/lachlandcp/jellyfin-editors-choice-plugin/raw/main/manifest.json` as a Jellyfin plugin repository
 2. Install **Editor's Choice** from the repository
 
-The next step is to follow one of the following three options.
+By default, Editor's Choice automatically uses the first available frontend injection method in this order:
+
+1. File Transformation
+2. JavaScript Injector
+3. Direct `jellyfin-web/index.html` injection
+
+You can override the automatic selection under **Editor's Choice → Technical settings**. Install either of the two helper plugins below to avoid direct changes to Jellyfin Web.
 
 ### Option 1: Install the File Transformation plugin (recommended)
-The easiest way is to install the plugin is to use the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation):
+The easiest way to load the frontend script is to use the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation):
 
 3. Add `https://www.iamparadox.dev/jellyfin/plugins/manifest.json` as a plugin source repository on your Jellyfin server.
 4. Find "File Transformation" in the list and install it.
 5. Restart server
 
-### Option 2: Script injection
-The next best way is to have **Editor's Choice** installed is to enable the plugin to inject the necessary script into the main web file. This requires correct permissions.
+### Option 2: Install the JavaScript Injector plugin
+Alternatively, install [JavaScript Injector](https://github.com/n00bcodr/Jellyfin-JavaScript-Injector). Editor's Choice registers its frontend loader automatically; no script needs to be pasted into the injector settings.
+
+3. Add the JavaScript Injector repository that matches your Jellyfin version.
+4. Find "JavaScript Injector" in the plugin catalog and install it.
+5. Restart server.
+
+### Option 3: Direct script injection
+If neither helper plugin is available, **Editor's Choice** falls back to injecting the necessary script into the main web file. This requires correct permissions.
 
 3. Make sure the user executing the Jellyfin server application has permissions to write to the `jellyfin-web/index.html` file.
-4. In the **Editor's Choice** plugin settings, enable 'Client script injection' in the Technical Settings section.
-5. Restart server
+4. Restart server.
 
 **The client script will fail to inject automatically into the jellyfin-web server if there is a difference in permission between the owner of the web files (root, or www-data, etc.) and the executor of the main jellyfin-server. This often happens because...**
 * **Docker** - the container is being run as a non-root user while having been built as a root user, causing the web files to be owned by root. To solve this, you can remove any lines like `User: 1000:1000`, `GUID:`, `PID:`, etc. from the jellyfin docker compose file.
 * **Install from distro repositories** - the jellyfin-server will execute as the `jellyfin` user while the web files will be owned by `root`, `www-data`, etc. This can *likely* be fixed by adding the `jellyfin` (or whichever user your main jellyfin server runs as) user to the same group the jellyfin-web folders are owned by. You should only do this if they are owned by a group other than root, and will have to lookup how to manage permissions on your specific distro.
 
-### Option 3: Manually insert script tag
+### Option 4: Manually insert script tag
 The final way is to manually amend the `jellyfin-web/index.html` file yourself.
 
 If you manually insert the script tag, you will have to manually insert it on every Jellyfin update, as the index.html file will get overwritten.
 
-3. In Jellyfin's program files, open `jellyfin-web/index.html`.
-4. Before the `</body>` tag, insert the following: `<script plugin="EditorsChoice" defer="defer" src="/editorschoice/script"></script>`. If you have a base path set, change `src="/editorschoice/script"` to `src="/YOUR_BASE_PATH/editorschoice/script"`.
-5. Clear your site cookies / local storage to get rid of the cached index file and receive a new one from the server.
+3. Select "Disabled / manual injection" under **Editor's Choice → Technical settings**.
+4. In Jellyfin's program files, open `jellyfin-web/index.html`.
+5. Before the `</body>` tag, insert the following: `<script plugin="EditorsChoice" defer="defer" src="/editorschoice/script"></script>`. If you have a base path set, change `src="/editorschoice/script"` to `src="/YOUR_BASE_PATH/editorschoice/script"`.
+6. Clear your site cookies / local storage to get rid of the cached index file and receive a new one from the server.


### PR DESCRIPTION
## Depends on
- #82 — this branch is based on the Jellyfin 12 support branch. Once #82 is merged, GitHub will reduce this PR to the automatic injection commit.

## Summary
- add an `Automatic` frontend injection mode and make it the default
- prefer File Transformation, then JavaScript Injector, then direct `index.html` injection
- integrate with JavaScript Injector through its reflection-based `RegisterScript` API
- retain explicit modes for File Transformation, JavaScript Injector, direct injection, and disabled/manual setup
- replace existing Editors Choice script tags before File Transformation or direct injection to avoid duplicates
- document the automatic selection and all supported installation paths

## Why
Direct `index.html` writes can fail on read-only or containerized Jellyfin installations. Editors Choice already supported File Transformation and direct injection, but selection was manual and a failed or unavailable integration had no fallback. Automatic selection uses the least invasive available integration before attempting a direct file write.

## Testing
- rebased onto the Jellyfin 12 changes from #82
- `dotnet build EditorsChoicePlugin.sln -c Release`
- targets `.NET 10` and Jellyfin `12.0.0`
- build succeeds with 0 warnings and 0 errors
- `git diff --check feat/jellyfin-v12-dom-support...HEAD`