### PR TITLE
Allow combining recommendation modes

### DIFF
--- a/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
+++ b/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
@@ -144,7 +144,7 @@ public class EditorsChoiceActivityController : ControllerBase
                         OrderBy = new[] { (ItemSortBy.Random, SortOrder.Ascending) }
                     };
                     query.Limit = _config.RandomMediaCount * 2;
-                    initialResult = (List<BaseItem>)_libraryManager.GetItemList(query);
+                    initialResult = _libraryManager.GetItemList(query).ToList();
 
                     // Get ids of items in the favourites list
                     List<Guid> itemIds = new List<Guid>();
@@ -259,7 +259,7 @@ public class EditorsChoiceActivityController : ControllerBase
                     OrderBy = new[] { (ItemSortBy.Random, SortOrder.Descending) },
                     IsPlayed = _config.ShowPlayed ? null : false
                 };
-                initialResult = (List<BaseItem>)_libraryManager.GetItemList(queryItems);
+                initialResult = _libraryManager.GetItemList(queryItems).ToList();
 
                 // Of TV series that meet those criteria, loop through to find items that are recent enough. These are already ordered by recency, so can quit on first item that is too old.
                 List<Guid> itemIds = new List<Guid>();
@@ -272,7 +272,7 @@ public class EditorsChoiceActivityController : ControllerBase
                         ParentId = item.Id,
                         OrderBy = new[] { (ItemSortBy.IndexNumber, SortOrder.Descending )}
                     };
-                    List<BaseItem> seasons = (List<BaseItem>) _libraryManager.GetItemList(querySeasons);
+                    List<BaseItem> seasons = _libraryManager.GetItemList(querySeasons).ToList();
 
                     if (seasons.Count > 0) {
                         Guid latestSeasonId = seasons[0].Id;
@@ -285,7 +285,7 @@ public class EditorsChoiceActivityController : ControllerBase
                             ParentId = latestSeasonId,
                             OrderBy = new[] { (ItemSortBy.IndexNumber, SortOrder.Descending) }
                         };
-                        List<BaseItem> episodes = (List<BaseItem>) _libraryManager.GetItemList(queryEpisodes);
+                        List<BaseItem> episodes = _libraryManager.GetItemList(queryEpisodes).ToList();
                         
                         //_logger.LogInformation("Contains {0} episodes.", episodes.Count);
 
@@ -319,7 +319,7 @@ public class EditorsChoiceActivityController : ControllerBase
                     IsPlayed = _config.ShowPlayed ? null : false
                 };
                 queryMovies.Limit = _config.RandomMediaCount;
-                List<BaseItem> resultMovies = (List<BaseItem>) _libraryManager.GetItemList(queryMovies);
+                List<BaseItem> resultMovies = _libraryManager.GetItemList(queryMovies).ToList();
 
                 // Join the lists of recent films and recent series
                 foreach (BaseItem item in resultMovies) itemIds.Add(item.Id);
@@ -411,15 +411,15 @@ public class EditorsChoiceActivityController : ControllerBase
         }
         catch (Exception e)
         {
-            _logger.LogError(e.ToString());
-            return StatusCode(503);
+            _logger.LogError(e, "Failed to build the Editors Choice response.");
+            return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
     }
 
     private List<BaseItem> PrepareResult(InternalItemsQuery query, Jellyfin.Database.Implementations.Entities.User? activeUser)
     {
-        List<BaseItem> initialResult = (List<BaseItem>)_libraryManager.GetItemList(query);
+        List<BaseItem> initialResult = _libraryManager.GetItemList(query).ToList();
         List<BaseItem> result = [];
 
         // Randomly add items until we run out or reach the admin-set cap

--- a/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
+++ b/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
@@ -69,7 +69,6 @@ public class EditorsChoiceActivityController : ControllerBase
             InternalItemsQuery query;
             List<BaseItem> initialResult = [];
             List<BaseItem> result = [];
-            bool resultsEmpty = false;
             int? maximumParentRating = -2;
             int maximumParentRatingSubscore = 0;
             bool? mustHaveParentRating = null;
@@ -93,6 +92,14 @@ public class EditorsChoiceActivityController : ControllerBase
 
             Jellyfin.Database.Implementations.Entities.User? activeUser = _userManager.GetUserByName(name);
             if (activeUser == null) return NotFound();
+
+            HashSet<string> modes = (_config.Modes?.Length > 0 ? _config.Modes : [_config.Mode])
+                .Where(mode => !string.IsNullOrWhiteSpace(mode))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (modes.Count == 0)
+            {
+                modes.Add("RANDOM");
+            }
 
             // If the config is set to be user profile specific, then we need to set the rating to the user's max age rating.
             if (_config.MaximumParentRating == -2)
@@ -118,68 +125,60 @@ public class EditorsChoiceActivityController : ControllerBase
                 parentalRatingScore = new MediaBrowser.Model.Entities.ParentalRatingScore((int)maximumParentRating, maximumParentRatingSubscore);
             }
 
-            // If not showing random media, collect the editor user's favourited items
-            if (_config.Mode == "FAVOURITES")
+            // Collect the editor user's favourited items when that source is enabled.
+            if (modes.Contains("FAVOURITES"))
             {
 
-                // Use random fallback if no editor ID set
-                if (_config.EditorUserId == null || _config.EditorUserId == "" || _config.EditorUserId.Length < 16)
+                if (Guid.TryParse(_config.EditorUserId, out Guid editorUserId))
                 {
-                    resultsEmpty = true;
-                }
-                else
-                {
-                    Jellyfin.Database.Implementations.Entities.User? editorUser = _userManager.GetUserById(Guid.Parse(_config.EditorUserId));
+                    Jellyfin.Database.Implementations.Entities.User? editorUser = _userManager.GetUserById(editorUserId);
 
-                    // Get the favourites list
-                    query = new InternalItemsQuery(editorUser)
+                    if (editorUser != null)
                     {
-                        IsFavorite = true,
-                        IncludeItemsByName = true,
-                        IncludeItemTypes = [BaseItemKind.Series, BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Season], // Editor may have favourited individual episodes or seasons - we will handle this later
-                        MinCommunityRating = minimumRating,
-                        MinCriticRating = minimumCriticRating,
-                        MaxParentalRating = parentalRatingScore,
-                        HasParentalRating = mustHaveParentRating,
-                        OrderBy = new[] { (ItemSortBy.Random, SortOrder.Ascending) }
-                    };
-                    query.Limit = _config.RandomMediaCount * 2;
-                    initialResult = _libraryManager.GetItemList(query).ToList();
-
-                    // Get ids of items in the favourites list
-                    List<Guid> itemIds = new List<Guid>();
-                    foreach (var item in initialResult)
-                    {
-                        if (!itemIds.Contains(item.Id))
+                        // Read the editor's favourites, but never expose them directly.
+                        query = new InternalItemsQuery(editorUser)
                         {
-                            // Only include if active user has parental access to this item
-                            if (item.IsVisible(activeUser))
+                            IsFavorite = true,
+                            IncludeItemsByName = true,
+                            IncludeItemTypes = [BaseItemKind.Series, BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Season], // Editor may have favourited individual episodes or seasons - we will handle this later
+                            MinCommunityRating = minimumRating,
+                            MinCriticRating = minimumCriticRating,
+                            MaxParentalRating = parentalRatingScore,
+                            HasParentalRating = mustHaveParentRating,
+                            OrderBy = new[] { (ItemSortBy.Random, SortOrder.Ascending) }
+                        };
+                        query.Limit = _config.RandomMediaCount * 2;
+                        initialResult = _libraryManager.GetItemList(query).ToList();
+
+                        // Re-query only visible IDs as the active user. PrepareResult
+                        // performs a final visibility check after promoting episodes or seasons.
+                        List<Guid> itemIds = [];
+                        foreach (var item in initialResult)
+                        {
+                            if (!itemIds.Contains(item.Id) && item.IsVisible(activeUser))
                             {
                                 itemIds.Add(item.Id);
                             }
                         }
+
+                        query = new InternalItemsQuery(activeUser)
+                        {
+                            ItemIds = [.. itemIds],
+                            IncludeItemTypes = [BaseItemKind.Series, BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Season], // Editor may have favourited individual episodes or seasons - we will handle this later
+                            IsPlayed = _config.ShowPlayed ? null : false
+                        };
+                        result.AddRange(PrepareResult(query, activeUser));
                     }
-
-                    // Query items from the active user to ensure access
-                    query = new InternalItemsQuery(activeUser)
-                    {
-                        ItemIds = [.. itemIds],
-                        IncludeItemTypes = [BaseItemKind.Series, BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Season], // Editor may have favourited individual episodes or seasons - we will handle this later
-                        IsPlayed = _config.ShowPlayed ? null : false
-                    };
-                    result = PrepareResult(query, activeUser);
-
-                    // If the result is empty (i.e. the active user doesn't have access to any of the items), fallback to random mode.
-                    resultsEmpty = result.Count == 0;
                 }
 
             }
 
-            if (_config.Mode == "COLLECTIONS")
+            if (modes.Contains("COLLECTIONS"))
             {
                 List<string> remainingCollections = _config.SelectedCollections.ToList();
+                List<BaseItem> collectionResult = [];
 
-                while (result.Count == 0 && remainingCollections.Count > 0)
+                while (collectionResult.Count == 0 && remainingCollections.Count > 0)
                 { // if a collection is totally inaccessible due to user visibility or excessive filters configured, we need to try another collection
                     int collectionR = new Random().Next(remainingCollections.Count);
                     string collectionId = remainingCollections[collectionR];
@@ -214,15 +213,14 @@ public class EditorsChoiceActivityController : ControllerBase
                             IsPlayed = _config.ShowPlayed ? null : false
                         };
                         query.Limit = _config.RandomMediaCount * 2;
-                        result = PrepareResult(query, activeUser);
+                        collectionResult = PrepareResult(query, activeUser);
                     }
-
-                    // If the result is empty (i.e. the active user doesn't have access to any of the items), fallback to random mode.
-                    resultsEmpty = result.Count == 0;
                 }
+
+                result.AddRange(collectionResult);
             }
 
-            if (_config.Mode == "NEW")
+            if (modes.Contains("NEW"))
             {
                 DateTime newEndDate = DateTime.Today.AddMonths(-1);
 
@@ -331,13 +329,12 @@ public class EditorsChoiceActivityController : ControllerBase
                 };
                 finalQuery.Limit = _config.RandomMediaCount;
 
-                result = PrepareResult(finalQuery, activeUser);
-
-                resultsEmpty = result.Count == 0;
+                result.AddRange(PrepareResult(finalQuery, activeUser));
             }
 
-            // If showing random media is enabled OR the results list is currently empty, collect a random selection from the entire library
-            if (_config.Mode == "RANDOM" || resultsEmpty)
+            // Explicit random mode contributes random items. If every configured
+            // source is empty, retain the existing random fallback behaviour.
+            if (modes.Contains("RANDOM") || result.Count == 0)
             {
 
                 // Get all shows and movies
@@ -352,8 +349,14 @@ public class EditorsChoiceActivityController : ControllerBase
                     IsPlayed = _config.ShowPlayed ? null : false
                 };
                 query.Limit = _config.RandomMediaCount * 2;
-                result = PrepareResult(query, activeUser);
+                result.AddRange(PrepareResult(query, activeUser));
             }
+
+            result = result
+                .DistinctBy(item => item.Id)
+                .OrderBy(_ => Random.Shared.Next())
+                .Take(_config.RandomMediaCount)
+                .ToList();
 
             // Build response
             response = new Dictionary<string, object>();

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -8,7 +8,7 @@ const container = `
           <span class="material-icons chevron_left" aria-hidden="true"></span>
         </button>
 
-        <button class="splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button" id="editorsChoicePlayPause">
+        <button class="editorsChoicePlayPause splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button">
           <span class="splide__toggle__play material-icons play_arrow" aria-hidden="true"></span>
           <span class="splide__toggle__pause material-icons pause" aria-hidden="true"></span>
         </button>
@@ -184,7 +184,7 @@ const container = `
 
   /* ===== Hero mode ===== */
   .editorsChoiceHeroMode .editorsChoiceContainer { padding: 0 !important; }
-  .editorsChoiceHeroMode #homeTab { transform: translateY(-120px); }
+  #homeTab.editorsChoiceHeroMode { transform: translateY(-120px); }
 
   .editorsChoiceHeroMode .splide.cardScalable {
     border-radius: unset !important;
@@ -278,6 +278,9 @@ const container = `
 `;
 
 const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
+const HOME_CONTAINER_SELECTOR = "#indexPage:not(.hide) #homeTab.is-active .homeSectionsContainer";
+const EDITORS_CHOICE_ADDED_CLASS = "editorsChoiceAdded";
+const EDITORS_CHOICE_LOADING_CLASS = "editorsChoiceLoading";
 
 /* ===== Utils ===== */
 function shuffle(input) {
@@ -442,8 +445,11 @@ function renderNormalSlide(item, data, baseUrl) {
 async function setup() {
     console.log("Attempting creation of editors choice slider.");
 
-    const $containers = $(".homeSectionsContainer").filter((_, el) => !$(el).hasClass("editorsChoiceAdded"));
-    if (!$containers.length) return;
+    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => (
+        !element.classList.contains(EDITORS_CHOICE_ADDED_CLASS)
+        && !element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)
+    ));
+    if (!containers.length) return;
 
     try {
         await ensureSplideLoaded();
@@ -452,57 +458,65 @@ async function setup() {
         return;
     }
 
-    $containers.each((_, elem) => {
+    for (const elem of containers) {
         console.log("Fetching favourites data from API...");
+        elem.classList.add(EDITORS_CHOICE_LOADING_CLASS);
 
         ApiClient.fetch({ url: ApiClient.getUrl("/EditorsChoice/favourites"), type: "GET" })
             .then((response) => response.json())
             .then((data) => {
                 if (data.hideOnTvLayout && document.documentElement.classList.contains("layout-tv")) {
                     console.log("Editors Choice: hidden on TV layout by configuration.");
+                    elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
                     return;
                 }
 
                 const favourites = shuffle(data.favourites || []);
-                const $containerElem = $(container);
+                const template = document.createElement("template");
+                template.innerHTML = container.trim();
+                const content = template.content.cloneNode(true);
+                const containerElem = content.querySelector(".editorsChoiceContainer");
                 const containerId = `editorsChoice-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 
-                $containerElem.first().attr("id", containerId);
-                $containerElem.first().addClass(`editorsChoiceHeight-${data.bannerHeight}`);
-                $(elem).prepend($containerElem);
+                containerElem.id = containerId;
+                containerElem.classList.add(`editorsChoiceHeight-${data.bannerHeight}`);
+                elem.prepend(content);
 
                 // TV focus workaround
                 let focusResolved = false;
-                $(`.layout-tv #${containerId} .emby-scrollbuttons button`).on("focus", function () {
-                    if (focusResolved) return;
-                    $('[is="emby-tabs"] .emby-button').first().trigger("focus");
-                    focusResolved = true;
+                containerElem.querySelectorAll(".emby-scrollbuttons button").forEach((button) => {
+                    button.addEventListener("focus", () => {
+                        if (focusResolved || !document.documentElement.classList.contains("layout-tv")) return;
+                        document.querySelector('[is="emby-tabs"] .emby-button')?.focus();
+                        focusResolved = true;
+                    });
                 });
 
-                if (data.useHeroLayout) document.body.classList.add("editorsChoiceHeroMode");
+                const homeTab = elem.closest("#homeTab");
+                if (homeTab) homeTab.classList.toggle("editorsChoiceHeroMode", !!data.useHeroLayout);
 
                 if ("heading" in data && data.heading && !data.useHeroLayout) {
-                    $($containerElem).prepend(`<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
+                    containerElem.insertAdjacentHTML("afterbegin", `<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
                 }
 
                 const baseUrl = getBaseUrl();
-                const $list = $(`#${containerId} .editorsChoiceItemsContainer`);
+                const list = containerElem.querySelector(".editorsChoiceItemsContainer");
 
                 for (const item of favourites) {
                     const html = data.useHeroLayout
                         ? renderHeroSlide(item, data, baseUrl)
                         : renderNormalSlide(item, data, baseUrl);
 
-                    $list.append(html);
+                    list.insertAdjacentHTML("beforeend", html);
                 }
 
-                $(elem).addClass("editorsChoiceAdded");
+                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
 
-                // Toggle autoplay control visibility (button exists: #editorsChoicePlayPause)
-                const playPauseBtn = document.getElementById("editorsChoicePlayPause");
+                // Toggle autoplay control visibility.
+                const playPauseBtn = containerElem.querySelector(".editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
 
-                new Splide(`#${containerId} .splide`, {
+                new Splide(containerElem.querySelector(".splide"), {
                     type: data.transitionEffect ?? "loop",
                     autoplay: !!data.autoplay,
                     rewind: true,
@@ -512,37 +526,76 @@ async function setup() {
                     height: `${data.bannerHeight + (data.useHeroLayout ? 180 : 0)}px`, // Add 80px to the banner image height in hero mode to compensate for navbar overlay
                 }).mount();
             })
-            .catch((e) => console.warn("Editors Choice: failed to fetch/render.", e));
+            .catch((e) => {
+                elem.classList.remove(EDITORS_CHOICE_ADDED_CLASS);
+                console.warn("Editors Choice: failed to fetch/render.", e);
+            })
+            .finally(() => elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS));
+    }
+}
+
+let setupScheduled = false;
+
+function scheduleSetup() {
+    if (setupScheduled) return;
+
+    setupScheduled = true;
+    window.requestAnimationFrame(() => {
+        setupScheduled = false;
+        setup();
     });
 }
 
-window.onload = function () {
-    // Detect if container is ready to setup slider
-    const target = document.getElementById("reactRoot");
+function nodeContainsHomeContainer(node) {
+    if (!(node instanceof Element)) return false;
+
+    return node.matches(HOME_CONTAINER_SELECTOR)
+        || !!node.querySelector(HOME_CONTAINER_SELECTOR)
+        || !!node.closest(HOME_CONTAINER_SELECTOR);
+}
+
+function initializeEditorsChoice() {
+    // Jellyfin 12 mounts the legacy home tab as a nested React subtree. Observe
+    // the React root when available and fall back to body for older web clients.
+    const target = document.getElementById("reactRoot") || document.body;
     if (!target) {
-        console.warn("Editors Choice: reactRoot not found.");
+        console.warn("Editors Choice: page root not found.");
         return;
     }
 
     const observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
-            const newNodes = mutation.addedNodes;
-            if (!newNodes || !newNodes.length) continue;
-
-            $(newNodes).each(function () {
-                const $node = $(this);
-                if ($node.hasClass("section0") && !$node.hasClass("editorsChoiceAdded")) {
-                    setup();
+            if (mutation.type === "attributes") {
+                const element = mutation.target;
+                if (element instanceof Element && element.matches("#indexPage, #homeTab")) {
+                    scheduleSetup();
+                    return;
                 }
-            });
+            }
+
+            for (const node of mutation.addedNodes) {
+                if (nodeContainsHomeContainer(node)) {
+                    scheduleSetup();
+                    return;
+                }
+            }
         }
     });
 
-    observer.observe(target, { attributes: true, childList: true, characterData: true, subtree: true });
+    observer.observe(target, {
+        attributes: true,
+        attributeFilter: ["class"],
+        childList: true,
+        subtree: true,
+    });
+
+    // The script can be loaded after the home tab has already mounted.
+    scheduleSetup();
 
     // Remind user that their favourites will be public when they add a new favourite.
-    $("body").on("click", '[is="emby-ratingbutton"]', function () {
-        if ($(this).hasClass("ratingbutton-withrating")) return;
+    document.body.addEventListener("click", (event) => {
+        const ratingButton = event.target.closest?.('[is="emby-ratingbutton"]');
+        if (!ratingButton || ratingButton.classList.contains("ratingbutton-withrating")) return;
 
         ApiClient.getPluginConfiguration(GUID).then((data) => {
             if (ApiClient.getCurrentUserId() === data.EditorUserId) {
@@ -550,4 +603,10 @@ window.onload = function () {
             }
         });
     });
-};
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeEditorsChoice, { once: true });
+} else {
+    initializeEditorsChoice();
+}

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -281,6 +281,8 @@ const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
 const HOME_CONTAINER_SELECTOR = "#indexPage:not(.hide) #homeTab.is-active .homeSectionsContainer";
 const EDITORS_CHOICE_ADDED_CLASS = "editorsChoiceAdded";
 const EDITORS_CHOICE_LOADING_CLASS = "editorsChoiceLoading";
+const initializingContainers = new WeakSet();
+const initializedContainers = new WeakSet();
 
 /* ===== Utils ===== */
 function shuffle(input) {
@@ -445,28 +447,61 @@ function renderNormalSlide(item, data, baseUrl) {
 async function setup() {
     console.log("Attempting creation of editors choice slider.");
 
-    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => (
-        !element.classList.contains(EDITORS_CHOICE_ADDED_CLASS)
-        && !element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)
-    ));
+    // Claim each container synchronously. setup() can be scheduled again while
+    // Splide is loading, so waiting before setting this marker can render the
+    // same slider multiple times.
+    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => {
+        if (element.querySelector(":scope > .editorsChoiceContainer")) {
+            initializedContainers.add(element);
+            element.classList.add(EDITORS_CHOICE_ADDED_CLASS);
+            return false;
+        }
+
+        if (initializingContainers.has(element) || initializedContainers.has(element)) return false;
+        if (element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)) return false;
+
+        initializingContainers.add(element);
+        element.classList.add(EDITORS_CHOICE_LOADING_CLASS);
+        return true;
+    });
     if (!containers.length) return;
 
     try {
         await ensureSplideLoaded();
     } catch (e) {
+        for (const elem of containers) {
+            initializingContainers.delete(elem);
+            elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+        }
         console.warn("Editors Choice: Splide failed to load.", e);
         return;
     }
 
     for (const elem of containers) {
+        if (!elem.isConnected || !elem.matches(HOME_CONTAINER_SELECTOR)) {
+            initializingContainers.delete(elem);
+            elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+            continue;
+        }
+
         console.log("Fetching favourites data from API...");
-        elem.classList.add(EDITORS_CHOICE_LOADING_CLASS);
+        let containerElem;
 
         ApiClient.fetch({ url: ApiClient.getUrl("/EditorsChoice/favourites"), type: "GET" })
             .then((response) => response.json())
             .then((data) => {
+                if (!elem.isConnected || !elem.matches(HOME_CONTAINER_SELECTOR)) return;
+
+                const existingContainer = elem.querySelector(":scope > .editorsChoiceContainer");
+                if (existingContainer) {
+                    initializedContainers.add(elem);
+                    elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
+                    return;
+                }
+
                 if (data.hideOnTvLayout && document.documentElement.classList.contains("layout-tv")) {
                     console.log("Editors Choice: hidden on TV layout by configuration.");
+                    initializedContainers.add(elem);
                     elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
                     return;
                 }
@@ -475,7 +510,7 @@ async function setup() {
                 const template = document.createElement("template");
                 template.innerHTML = container.trim();
                 const content = template.content.cloneNode(true);
-                const containerElem = content.querySelector(".editorsChoiceContainer");
+                containerElem = content.querySelector(".editorsChoiceContainer");
                 const containerId = `editorsChoice-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 
                 containerElem.id = containerId;
@@ -510,8 +545,6 @@ async function setup() {
                     list.insertAdjacentHTML("beforeend", html);
                 }
 
-                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
-
                 // Toggle autoplay control visibility.
                 const playPauseBtn = containerElem.querySelector(".editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
@@ -525,12 +558,20 @@ async function setup() {
                     keyboard: true,
                     height: `${data.bannerHeight + (data.useHeroLayout ? 180 : 0)}px`, // Add 80px to the banner image height in hero mode to compensate for navbar overlay
                 }).mount();
+
+                initializedContainers.add(elem);
+                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
             })
             .catch((e) => {
+                containerElem?.remove();
+                initializedContainers.delete(elem);
                 elem.classList.remove(EDITORS_CHOICE_ADDED_CLASS);
                 console.warn("Editors Choice: failed to fetch/render.", e);
             })
-            .finally(() => elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS));
+            .finally(() => {
+                initializingContainers.delete(elem);
+                elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+            });
     }
 }
 

--- a/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
+++ b/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
@@ -16,6 +16,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string Mode { get; set; } = "";
 
+    public string[] Modes { get; set; } = [];
+
     public int RandomMediaCount { get; set; } = 5;
 
     public float MinimumRating { get; set; } = 0.0f;

--- a/EditorsChoicePlugin/Configuration/configPage.html
+++ b/EditorsChoicePlugin/Configuration/configPage.html
@@ -147,70 +147,38 @@
 
                     <hr />
                     <h2>Mode</h2>
-                    <div class="inputContainer">
-                        <label class="radio-label-block mdl-radio show-focus">
-                            <input type="radio" is="emby-radio" id="FavouritesMode" name="mode" value="FavouritesMode" class="mdl-radio__button" />
-                            <div class="mdl-radio__circles">
-                                <svg>
-                                    <defs>
-                                        <clipPath id="cutoff-fav"><circle cx="50%" cy="50%" r="50%"></circle></clipPath>
-                                    </defs>
-                                    <circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff-fav)"></circle>
-                                    <circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle>
-                                </svg>
-                                <div class="mdl-radio__focus-circle"></div>
-                            </div>
-                            <span class="radioButtonLabel mdl-radio__label">Favourites</span>
-                            <div class="fieldDescription">Shows items from the specified user's favourites</div>
-                        </label>
+                    <p>Select one or more sources. Results are combined, deduplicated, and limited by the maximum items setting.</p>
 
-                        <label class="radio-label-block mdl-radio show-focus">
-                            <input type="radio" is="emby-radio" id="RandomMode" name="mode" value="RandomMode" class="mdl-radio__button" />
-                            <div class="mdl-radio__circles">
-                                <svg>
-                                    <defs>
-                                        <clipPath id="cutoff-rand"><circle cx="50%" cy="50%" r="50%"></circle></clipPath>
-                                    </defs>
-                                    <circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff-rand)"></circle>
-                                    <circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle>
-                                </svg>
-                                <div class="mdl-radio__focus-circle"></div>
-                            </div>
-                            <span class="radioButtonLabel mdl-radio__label">Random</span>
-                            <div class="fieldDescription">Shows a random selection of items from your library</div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="FavouritesMode" name="modes" />
+                            <span class="checkboxLabel">Favourites</span>
                         </label>
+                        <div class="fieldDescription">Shows items from the specified user's favourites.</div>
+                    </div>
 
-                        <label class="radio-label-block mdl-radio show-focus">
-                            <input type="radio" is="emby-radio" id="CollectionsMode" name="mode" value="CollectionsMode" class="mdl-radio__button" />
-                            <div class="mdl-radio__circles">
-                                <svg>
-                                    <defs>
-                                        <clipPath id="cutoff-col"><circle cx="50%" cy="50%" r="50%"></circle></clipPath>
-                                    </defs>
-                                    <circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff-col)"></circle>
-                                    <circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle>
-                                </svg>
-                                <div class="mdl-radio__focus-circle"></div>
-                            </div>
-                            <span class="radioButtonLabel mdl-radio__label">Collections</span>
-                            <div class="fieldDescription">Shows items from the specified collections</div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="RandomMode" name="modes" />
+                            <span class="checkboxLabel">Random</span>
                         </label>
+                        <div class="fieldDescription">Shows a random selection of items from your library.</div>
+                    </div>
 
-                        <label class="radio-label-block mdl-radio show-focus">
-                            <input type="radio" is="emby-radio" id="NewMode" name="mode" value="NewMode" class="mdl-radio__button" />
-                            <div class="mdl-radio__circles">
-                                <svg>
-                                    <defs>
-                                        <clipPath id="cutoff-new"><circle cx="50%" cy="50%" r="50%"></circle></clipPath>
-                                    </defs>
-                                    <circle class="mdl-radio__outer-circle" cx="50%" cy="50%" r="50%" fill="none" stroke="currentcolor" stroke-width="0.26em" clip-path="url(#cutoff-new)"></circle>
-                                    <circle class="mdl-radio__inner-circle" cx="50%" cy="50%" r="25%" fill="currentcolor"></circle>
-                                </svg>
-                                <div class="mdl-radio__focus-circle"></div>
-                            </div>
-                            <span class="radioButtonLabel mdl-radio__label">New</span>
-                            <div class="fieldDescription">Shows only movies and shows with episodes that premiered recently</div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="CollectionsMode" name="modes" />
+                            <span class="checkboxLabel">Collections</span>
                         </label>
+                        <div class="fieldDescription">Shows items from the specified collections.</div>
+                    </div>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="NewMode" name="modes" />
+                            <span class="checkboxLabel">New</span>
+                        </label>
+                        <div class="fieldDescription">Shows movies and shows with episodes that premiered recently.</div>
                     </div>
 
                     <div id="EditorUserId-container" class="selectContainer" style="display:none;">
@@ -429,10 +397,13 @@
                         $('#DoScriptInject').first().prop('checked', config.DoScriptInject);
                         $('#FileTransformation').first().prop('checked', config.FileTransformation);
                         $('#ShowRandomMedia').first().prop('checked', config.ShowRandomMedia);
-                        $('#FavouritesMode').first().prop('checked', config.Mode == 'FAVOURITES');
-                        $('#RandomMode').first().prop('checked', config.Mode == 'RANDOM');
-                        $('#CollectionsMode').first().prop('checked', config.Mode == 'COLLECTIONS');
-                        $('#NewMode').first().prop('checked', config.Mode == 'NEW');
+                        var configuredModes = Array.isArray(config.Modes) && config.Modes.length
+                            ? config.Modes
+                            : [config.Mode];
+                        $('#FavouritesMode').first().prop('checked', configuredModes.includes('FAVOURITES'));
+                        $('#RandomMode').first().prop('checked', configuredModes.includes('RANDOM'));
+                        $('#CollectionsMode').first().prop('checked', configuredModes.includes('COLLECTIONS'));
+                        $('#NewMode').first().prop('checked', configuredModes.includes('NEW'));
                         $('#RandomMediaCount').val(config.RandomMediaCount);
                         $('#MinimumRating').val(config.MinimumRating);
                         $('#MinimumCriticRating').val(config.MinimumCriticRating);
@@ -453,11 +424,13 @@
                         $("#PlayButtonText").val(config.PlayButtonText);
                         $('#HideOnTvLayout').first().prop('checked', config.HideOnTvLayout);
 
-                        if (config.Mode == 'FAVOURITES') {
+                        if (configuredModes.includes('FAVOURITES')) {
                             $('#EditorUserId-container').show();
-                        } else if (config.Mode == 'COLLECTIONS') {
+                        }
+                        if (configuredModes.includes('COLLECTIONS')) {
                             $('#CollectionsList-container').show();
-                        } else if (config.Mode == "NEW") {
+                        }
+                        if (configuredModes.includes('NEW')) {
                             $('#NewTimeLimit-container').show();
                         }
 
@@ -590,20 +563,16 @@
                         config.TransitionEffect = $("#TransitionEffectSelect").val();
                         config.HeroBackdropPosition = $("#HeroBackdropPositionSelect").val();
 
-                        if ($('#FavouritesMode').first().is(':checked')) {
-                            config.Mode = "FAVOURITES";
-                            config.ShowRandomMedia = false;
-                        } else if ($('#RandomMode').first().is(':checked')) {
-                            config.Mode = "RANDOM";
-                            config.ShowRandomMedia = true;
-                        } else if ($('#CollectionsMode').first().is(':checked')) {
-                            config.Mode = "COLLECTIONS";
-                            config.ShowRandomMedia = false;
-                        } else if ($('#NewMode').first().is(':checked')) {
-                            config.Mode = "NEW";
-                            config.ShowRandomMedia = false;
+                        var selectedModes = [];
+                        if ($('#FavouritesMode').first().is(':checked')) selectedModes.push('FAVOURITES');
+                        if ($('#RandomMode').first().is(':checked')) selectedModes.push('RANDOM');
+                        if ($('#CollectionsMode').first().is(':checked')) selectedModes.push('COLLECTIONS');
+                        if ($('#NewMode').first().is(':checked')) selectedModes.push('NEW');
+                        if (!selectedModes.length) selectedModes.push('RANDOM');
 
-                        }
+                        config.Modes = selectedModes;
+                        config.Mode = selectedModes[0];
+                        config.ShowRandomMedia = selectedModes.includes('RANDOM');
 
                         let randomMediaCount = $('#RandomMediaCount').first().val();
                         if (randomMediaCount < 1 || randomMediaCount == '') {
@@ -654,7 +623,7 @@
                     return false;
                 });
 
-                $('input[name="mode"], #EnableAutoplay').on('change', function() {
+                $('input[name="modes"], #EnableAutoplay').on('change', function() {
                     $('#EditorUserId-container').toggle($('#FavouritesMode').is(':checked'));
                     $('#CollectionsList-container').toggle($('#CollectionsMode').is(':checked'));
                     $('#NewTimeLimit-container').toggle($('#NewMode').is(':checked'));

--- a/EditorsChoicePlugin/EditorsChoicePlugin.csproj
+++ b/EditorsChoicePlugin/EditorsChoicePlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,9 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Common" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Common" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/EditorsChoicePlugin/StartupService.cs
+++ b/EditorsChoicePlugin/StartupService.cs
@@ -62,6 +62,12 @@ public class StartupService : IScheduledTask
             }
         }
 
+        // Preserve configurations created before combined modes were available.
+        if (_config.Modes == null || _config.Modes.Length == 0)
+        {
+            _config.Modes = [_config.Mode];
+        }
+
         // Get base path from network config
         try
         {


### PR DESCRIPTION
## Summary
- replace the single mode choice with a multi-select for favourites, random items, collections, and new releases
- combine and deduplicate results under the existing maximum item count
- preserve existing single-mode configurations and the random fallback when configured sources are empty
- validate the configured editor user ID and re-query favourites as the active user before returning any item data
- retain the final active-user visibility check after episodes and seasons are promoted to their parent series

## Security
Favourites are never returned directly from the editor user query. Candidate IDs must be visible to the requesting user, are queried again in that user context, and pass a final `IsVisible(activeUser)` check before serialization.

## Testing
- Release build succeeds with 0 warnings and 0 errors

## Dependency
- based on and depends on #82 for Jellyfin 12 support

Closes #72