### PR TITLE
Play local trailers in slider backgrounds

### DIFF
--- a/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
+++ b/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
@@ -373,6 +373,15 @@ public class EditorsChoiceActivityController : ControllerBase
                     { "hasLogo", item.HasImage(MediaBrowser.Model.Entities.ImageType.Logo) }
                 };
 
+                if (_config.EnableBackgroundTrailers && item is IHasTrailers itemWithTrailers)
+                {
+                    BaseItem? localTrailer = itemWithTrailers.LocalTrailers.FirstOrDefault(trailer => trailer.IsVisible(activeUser));
+                    if (localTrailer != null)
+                    {
+                        itemObject.Add("localTrailerId", localTrailer.Id.ToString());
+                    }
+                }
+
                 if (_config.ShowDescription)
                 {
                     itemObject.Add("overview", item.Overview);
@@ -391,6 +400,7 @@ public class EditorsChoiceActivityController : ControllerBase
 
             response.Add("favourites", items);
             response.Add("autoplay", _config.EnableAutoplay);
+            response.Add("enableBackgroundTrailers", _config.EnableBackgroundTrailers);
             response.Add("autoplayInterval", _config.AutoplayInterval * 1000);
             response.Add("reduceImageSizes", _config.ReduceImageSize);
             response.Add("bannerHeight", _config.BannerHeight);

--- a/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
+++ b/EditorsChoicePlugin/Api/EditorsChoiceActivityController.cs
@@ -144,7 +144,7 @@ public class EditorsChoiceActivityController : ControllerBase
                         OrderBy = new[] { (ItemSortBy.Random, SortOrder.Ascending) }
                     };
                     query.Limit = _config.RandomMediaCount * 2;
-                    initialResult = (List<BaseItem>)_libraryManager.GetItemList(query);
+                    initialResult = _libraryManager.GetItemList(query).ToList();
 
                     // Get ids of items in the favourites list
                     List<Guid> itemIds = new List<Guid>();
@@ -259,7 +259,7 @@ public class EditorsChoiceActivityController : ControllerBase
                     OrderBy = new[] { (ItemSortBy.Random, SortOrder.Descending) },
                     IsPlayed = _config.ShowPlayed ? null : false
                 };
-                initialResult = (List<BaseItem>)_libraryManager.GetItemList(queryItems);
+                initialResult = _libraryManager.GetItemList(queryItems).ToList();
 
                 // Of TV series that meet those criteria, loop through to find items that are recent enough. These are already ordered by recency, so can quit on first item that is too old.
                 List<Guid> itemIds = new List<Guid>();
@@ -272,7 +272,7 @@ public class EditorsChoiceActivityController : ControllerBase
                         ParentId = item.Id,
                         OrderBy = new[] { (ItemSortBy.IndexNumber, SortOrder.Descending )}
                     };
-                    List<BaseItem> seasons = (List<BaseItem>) _libraryManager.GetItemList(querySeasons);
+                    List<BaseItem> seasons = _libraryManager.GetItemList(querySeasons).ToList();
 
                     if (seasons.Count > 0) {
                         Guid latestSeasonId = seasons[0].Id;
@@ -285,7 +285,7 @@ public class EditorsChoiceActivityController : ControllerBase
                             ParentId = latestSeasonId,
                             OrderBy = new[] { (ItemSortBy.IndexNumber, SortOrder.Descending) }
                         };
-                        List<BaseItem> episodes = (List<BaseItem>) _libraryManager.GetItemList(queryEpisodes);
+                        List<BaseItem> episodes = _libraryManager.GetItemList(queryEpisodes).ToList();
                         
                         //_logger.LogInformation("Contains {0} episodes.", episodes.Count);
 
@@ -319,7 +319,7 @@ public class EditorsChoiceActivityController : ControllerBase
                     IsPlayed = _config.ShowPlayed ? null : false
                 };
                 queryMovies.Limit = _config.RandomMediaCount;
-                List<BaseItem> resultMovies = (List<BaseItem>) _libraryManager.GetItemList(queryMovies);
+                List<BaseItem> resultMovies = _libraryManager.GetItemList(queryMovies).ToList();
 
                 // Join the lists of recent films and recent series
                 foreach (BaseItem item in resultMovies) itemIds.Add(item.Id);
@@ -411,15 +411,15 @@ public class EditorsChoiceActivityController : ControllerBase
         }
         catch (Exception e)
         {
-            _logger.LogError(e.ToString());
-            return StatusCode(503);
+            _logger.LogError(e, "Failed to build the Editors Choice response.");
+            return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
     }
 
     private List<BaseItem> PrepareResult(InternalItemsQuery query, Jellyfin.Database.Implementations.Entities.User? activeUser)
     {
-        List<BaseItem> initialResult = (List<BaseItem>)_libraryManager.GetItemList(query);
+        List<BaseItem> initialResult = _libraryManager.GetItemList(query).ToList();
         List<BaseItem> result = [];
 
         // Randomly add items until we run out or reach the admin-set cap

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -8,7 +8,7 @@ const container = `
           <span class="material-icons chevron_left" aria-hidden="true"></span>
         </button>
 
-        <button class="splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button" id="editorsChoicePlayPause">
+        <button class="editorsChoicePlayPause splide__toggle emby-scrollbuttons-button paper-icon-button-light" type="button">
           <span class="splide__toggle__play material-icons play_arrow" aria-hidden="true"></span>
           <span class="splide__toggle__pause material-icons pause" aria-hidden="true"></span>
         </button>
@@ -184,7 +184,7 @@ const container = `
 
   /* ===== Hero mode ===== */
   .editorsChoiceHeroMode .editorsChoiceContainer { padding: 0 !important; }
-  .editorsChoiceHeroMode #homeTab { transform: translateY(-120px); }
+  #homeTab.editorsChoiceHeroMode { transform: translateY(-120px); }
 
   .editorsChoiceHeroMode .splide.cardScalable {
     border-radius: unset !important;
@@ -278,6 +278,9 @@ const container = `
 `;
 
 const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
+const HOME_CONTAINER_SELECTOR = "#indexPage:not(.hide) #homeTab.is-active .homeSectionsContainer";
+const EDITORS_CHOICE_ADDED_CLASS = "editorsChoiceAdded";
+const EDITORS_CHOICE_LOADING_CLASS = "editorsChoiceLoading";
 
 /* ===== Utils ===== */
 function shuffle(input) {
@@ -442,8 +445,11 @@ function renderNormalSlide(item, data, baseUrl) {
 async function setup() {
     console.log("Attempting creation of editors choice slider.");
 
-    const $containers = $(".homeSectionsContainer").filter((_, el) => !$(el).hasClass("editorsChoiceAdded"));
-    if (!$containers.length) return;
+    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => (
+        !element.classList.contains(EDITORS_CHOICE_ADDED_CLASS)
+        && !element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)
+    ));
+    if (!containers.length) return;
 
     try {
         await ensureSplideLoaded();
@@ -452,57 +458,65 @@ async function setup() {
         return;
     }
 
-    $containers.each((_, elem) => {
+    for (const elem of containers) {
         console.log("Fetching favourites data from API...");
+        elem.classList.add(EDITORS_CHOICE_LOADING_CLASS);
 
         ApiClient.fetch({ url: ApiClient.getUrl("/EditorsChoice/favourites"), type: "GET" })
             .then((response) => response.json())
             .then((data) => {
                 if (data.hideOnTvLayout && document.documentElement.classList.contains("layout-tv")) {
                     console.log("Editors Choice: hidden on TV layout by configuration.");
+                    elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
                     return;
                 }
 
                 const favourites = shuffle(data.favourites || []);
-                const $containerElem = $(container);
+                const template = document.createElement("template");
+                template.innerHTML = container.trim();
+                const content = template.content.cloneNode(true);
+                const containerElem = content.querySelector(".editorsChoiceContainer");
                 const containerId = `editorsChoice-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 
-                $containerElem.first().attr("id", containerId);
-                $containerElem.first().addClass(`editorsChoiceHeight-${data.bannerHeight}`);
-                $(elem).prepend($containerElem);
+                containerElem.id = containerId;
+                containerElem.classList.add(`editorsChoiceHeight-${data.bannerHeight}`);
+                elem.prepend(content);
 
                 // TV focus workaround
                 let focusResolved = false;
-                $(`.layout-tv #${containerId} .emby-scrollbuttons button`).on("focus", function () {
-                    if (focusResolved) return;
-                    $('[is="emby-tabs"] .emby-button').first().trigger("focus");
-                    focusResolved = true;
+                containerElem.querySelectorAll(".emby-scrollbuttons button").forEach((button) => {
+                    button.addEventListener("focus", () => {
+                        if (focusResolved || !document.documentElement.classList.contains("layout-tv")) return;
+                        document.querySelector('[is="emby-tabs"] .emby-button')?.focus();
+                        focusResolved = true;
+                    });
                 });
 
-                if (data.useHeroLayout) document.body.classList.add("editorsChoiceHeroMode");
+                const homeTab = elem.closest("#homeTab");
+                if (homeTab) homeTab.classList.toggle("editorsChoiceHeroMode", !!data.useHeroLayout);
 
                 if ("heading" in data && data.heading && !data.useHeroLayout) {
-                    $($containerElem).prepend(`<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
+                    containerElem.insertAdjacentHTML("afterbegin", `<h2 class="sectionTitle sectionTitle-cards">${data.heading}</h2>`);
                 }
 
                 const baseUrl = getBaseUrl();
-                const $list = $(`#${containerId} .editorsChoiceItemsContainer`);
+                const list = containerElem.querySelector(".editorsChoiceItemsContainer");
 
                 for (const item of favourites) {
                     const html = data.useHeroLayout
                         ? renderHeroSlide(item, data, baseUrl)
                         : renderNormalSlide(item, data, baseUrl);
 
-                    $list.append(html);
+                    list.insertAdjacentHTML("beforeend", html);
                 }
 
-                $(elem).addClass("editorsChoiceAdded");
+                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
 
-                // Toggle autoplay control visibility (button exists: #editorsChoicePlayPause)
-                const playPauseBtn = document.getElementById("editorsChoicePlayPause");
+                // Toggle autoplay control visibility.
+                const playPauseBtn = containerElem.querySelector(".editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
 
-                new Splide(`#${containerId} .splide`, {
+                new Splide(containerElem.querySelector(".splide"), {
                     type: data.transitionEffect ?? "loop",
                     autoplay: !!data.autoplay,
                     rewind: true,
@@ -512,37 +526,76 @@ async function setup() {
                     height: `${data.bannerHeight + (data.useHeroLayout ? 180 : 0)}px`, // Add 80px to the banner image height in hero mode to compensate for navbar overlay
                 }).mount();
             })
-            .catch((e) => console.warn("Editors Choice: failed to fetch/render.", e));
+            .catch((e) => {
+                elem.classList.remove(EDITORS_CHOICE_ADDED_CLASS);
+                console.warn("Editors Choice: failed to fetch/render.", e);
+            })
+            .finally(() => elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS));
+    }
+}
+
+let setupScheduled = false;
+
+function scheduleSetup() {
+    if (setupScheduled) return;
+
+    setupScheduled = true;
+    window.requestAnimationFrame(() => {
+        setupScheduled = false;
+        setup();
     });
 }
 
-window.onload = function () {
-    // Detect if container is ready to setup slider
-    const target = document.getElementById("reactRoot");
+function nodeContainsHomeContainer(node) {
+    if (!(node instanceof Element)) return false;
+
+    return node.matches(HOME_CONTAINER_SELECTOR)
+        || !!node.querySelector(HOME_CONTAINER_SELECTOR)
+        || !!node.closest(HOME_CONTAINER_SELECTOR);
+}
+
+function initializeEditorsChoice() {
+    // Jellyfin 12 mounts the legacy home tab as a nested React subtree. Observe
+    // the React root when available and fall back to body for older web clients.
+    const target = document.getElementById("reactRoot") || document.body;
     if (!target) {
-        console.warn("Editors Choice: reactRoot not found.");
+        console.warn("Editors Choice: page root not found.");
         return;
     }
 
     const observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
-            const newNodes = mutation.addedNodes;
-            if (!newNodes || !newNodes.length) continue;
-
-            $(newNodes).each(function () {
-                const $node = $(this);
-                if ($node.hasClass("section0") && !$node.hasClass("editorsChoiceAdded")) {
-                    setup();
+            if (mutation.type === "attributes") {
+                const element = mutation.target;
+                if (element instanceof Element && element.matches("#indexPage, #homeTab")) {
+                    scheduleSetup();
+                    return;
                 }
-            });
+            }
+
+            for (const node of mutation.addedNodes) {
+                if (nodeContainsHomeContainer(node)) {
+                    scheduleSetup();
+                    return;
+                }
+            }
         }
     });
 
-    observer.observe(target, { attributes: true, childList: true, characterData: true, subtree: true });
+    observer.observe(target, {
+        attributes: true,
+        attributeFilter: ["class"],
+        childList: true,
+        subtree: true,
+    });
+
+    // The script can be loaded after the home tab has already mounted.
+    scheduleSetup();
 
     // Remind user that their favourites will be public when they add a new favourite.
-    $("body").on("click", '[is="emby-ratingbutton"]', function () {
-        if ($(this).hasClass("ratingbutton-withrating")) return;
+    document.body.addEventListener("click", (event) => {
+        const ratingButton = event.target.closest?.('[is="emby-ratingbutton"]');
+        if (!ratingButton || ratingButton.classList.contains("ratingbutton-withrating")) return;
 
         ApiClient.getPluginConfiguration(GUID).then((data) => {
             if (ApiClient.getCurrentUserId() === data.EditorUserId) {
@@ -550,4 +603,10 @@ window.onload = function () {
             }
         });
     });
-};
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeEditorsChoice, { once: true });
+} else {
+    initializeEditorsChoice();
+}

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -281,6 +281,8 @@ const GUID = "70bb2ec1-f19e-46b5-b49a-942e6b96ebae";
 const HOME_CONTAINER_SELECTOR = "#indexPage:not(.hide) #homeTab.is-active .homeSectionsContainer";
 const EDITORS_CHOICE_ADDED_CLASS = "editorsChoiceAdded";
 const EDITORS_CHOICE_LOADING_CLASS = "editorsChoiceLoading";
+const initializingContainers = new WeakSet();
+const initializedContainers = new WeakSet();
 
 /* ===== Utils ===== */
 function shuffle(input) {
@@ -445,28 +447,61 @@ function renderNormalSlide(item, data, baseUrl) {
 async function setup() {
     console.log("Attempting creation of editors choice slider.");
 
-    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => (
-        !element.classList.contains(EDITORS_CHOICE_ADDED_CLASS)
-        && !element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)
-    ));
+    // Claim each container synchronously. setup() can be scheduled again while
+    // Splide is loading, so waiting before setting this marker can render the
+    // same slider multiple times.
+    const containers = Array.from(document.querySelectorAll(HOME_CONTAINER_SELECTOR)).filter((element) => {
+        if (element.querySelector(":scope > .editorsChoiceContainer")) {
+            initializedContainers.add(element);
+            element.classList.add(EDITORS_CHOICE_ADDED_CLASS);
+            return false;
+        }
+
+        if (initializingContainers.has(element) || initializedContainers.has(element)) return false;
+        if (element.classList.contains(EDITORS_CHOICE_LOADING_CLASS)) return false;
+
+        initializingContainers.add(element);
+        element.classList.add(EDITORS_CHOICE_LOADING_CLASS);
+        return true;
+    });
     if (!containers.length) return;
 
     try {
         await ensureSplideLoaded();
     } catch (e) {
+        for (const elem of containers) {
+            initializingContainers.delete(elem);
+            elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+        }
         console.warn("Editors Choice: Splide failed to load.", e);
         return;
     }
 
     for (const elem of containers) {
+        if (!elem.isConnected || !elem.matches(HOME_CONTAINER_SELECTOR)) {
+            initializingContainers.delete(elem);
+            elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+            continue;
+        }
+
         console.log("Fetching favourites data from API...");
-        elem.classList.add(EDITORS_CHOICE_LOADING_CLASS);
+        let containerElem;
 
         ApiClient.fetch({ url: ApiClient.getUrl("/EditorsChoice/favourites"), type: "GET" })
             .then((response) => response.json())
             .then((data) => {
+                if (!elem.isConnected || !elem.matches(HOME_CONTAINER_SELECTOR)) return;
+
+                const existingContainer = elem.querySelector(":scope > .editorsChoiceContainer");
+                if (existingContainer) {
+                    initializedContainers.add(elem);
+                    elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
+                    return;
+                }
+
                 if (data.hideOnTvLayout && document.documentElement.classList.contains("layout-tv")) {
                     console.log("Editors Choice: hidden on TV layout by configuration.");
+                    initializedContainers.add(elem);
                     elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
                     return;
                 }
@@ -475,7 +510,7 @@ async function setup() {
                 const template = document.createElement("template");
                 template.innerHTML = container.trim();
                 const content = template.content.cloneNode(true);
-                const containerElem = content.querySelector(".editorsChoiceContainer");
+                containerElem = content.querySelector(".editorsChoiceContainer");
                 const containerId = `editorsChoice-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 
                 containerElem.id = containerId;
@@ -510,8 +545,6 @@ async function setup() {
                     list.insertAdjacentHTML("beforeend", html);
                 }
 
-                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
-
                 // Toggle autoplay control visibility.
                 const playPauseBtn = containerElem.querySelector(".editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
@@ -525,12 +558,20 @@ async function setup() {
                     keyboard: true,
                     height: `${data.bannerHeight + (data.useHeroLayout ? 180 : 0)}px`, // Add 80px to the banner image height in hero mode to compensate for navbar overlay
                 }).mount();
+
+                initializedContainers.add(elem);
+                elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);
             })
             .catch((e) => {
+                containerElem?.remove();
+                initializedContainers.delete(elem);
                 elem.classList.remove(EDITORS_CHOICE_ADDED_CLASS);
                 console.warn("Editors Choice: failed to fetch/render.", e);
             })
-            .finally(() => elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS));
+            .finally(() => {
+                initializingContainers.delete(elem);
+                elem.classList.remove(EDITORS_CHOICE_LOADING_CLASS);
+            });
     }
 }
 

--- a/EditorsChoicePlugin/Api/client.js
+++ b/EditorsChoicePlugin/Api/client.js
@@ -99,7 +99,22 @@ const container = `
     color: rgba(255, 255, 255, 0.8);
     text-decoration: none;
     background-position-y: 52%;
+    overflow: hidden;
+    position: relative;
   }
+
+  .editorsChoiceTrailer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0;
+    transition: opacity 0.5s ease;
+    z-index: 0;
+  }
+
+  .editorsChoiceTrailer.is-playing { opacity: 1; }
 
   .editorsChoiceItemBanner:nth-child(odd) { background-position-y: 48%; }
 
@@ -122,6 +137,8 @@ const container = `
     padding: 30px;
     box-sizing: border-box;
     background: linear-gradient(90deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0) 60%, rgba(0,0,0,0) 100%);
+    position: relative;
+    z-index: 1;
   }
 
   /* ===== Content ===== */
@@ -344,6 +361,72 @@ function buildBannerSizeParam(reduceImageSizes) {
     return `?width=${w}`;
 }
 
+function buildBackgroundTrailer(item, data) {
+    if (!data.enableBackgroundTrailers || !item.localTrailerId) return "";
+    return `<video class="editorsChoiceTrailer" data-trailer-id="${item.localTrailerId}" muted loop playsinline preload="none" aria-hidden="true"></video>`;
+}
+
+function getTrailerStreamUrl(trailerId) {
+    return ApiClient.getUrl(`Videos/${trailerId}/stream`, {
+        Static: true,
+        MediaSourceId: trailerId,
+        DeviceId: ApiClient.deviceId(),
+        ApiKey: ApiClient.accessToken(),
+    });
+}
+
+function configureBackgroundTrailers(splide, containerElem) {
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches || navigator.connection?.saveData) return;
+
+    let playTimer;
+    let pendingVideo;
+
+    const stopTrailer = (slide) => {
+        const video = slide?.querySelector?.(".editorsChoiceTrailer");
+        if (!video) return;
+        if (video === pendingVideo) {
+            clearTimeout(playTimer);
+            pendingVideo = null;
+        }
+        video.pause();
+        video.classList.remove("is-playing");
+        if (video.readyState > 0) video.currentTime = 0;
+    };
+
+    const startTrailer = (slide) => {
+        clearTimeout(playTimer);
+        const video = slide?.querySelector?.(".editorsChoiceTrailer");
+        if (!video) return;
+        pendingVideo = video;
+
+        playTimer = window.setTimeout(() => {
+            pendingVideo = null;
+            if (!slide.classList.contains("is-active") || document.hidden) return;
+            if (!video.src) video.src = getTrailerStreamUrl(video.dataset.trailerId);
+            video.play()
+                .then(() => {
+                    if (slide.classList.contains("is-active") && !document.hidden) {
+                        video.classList.add("is-playing");
+                    } else {
+                        stopTrailer(slide);
+                    }
+                })
+                .catch(() => video.classList.remove("is-playing"));
+        }, 1500);
+    };
+
+    splide.on("active", (slide) => startTrailer(slide.slide));
+    splide.on("inactive", (slide) => stopTrailer(slide.slide));
+
+    document.addEventListener("visibilitychange", () => {
+        if (document.hidden) {
+            containerElem.querySelectorAll(".editorsChoiceTrailer").forEach((video) => stopTrailer(video.closest(".splide__slide")));
+        } else {
+            startTrailer(containerElem.querySelector(".splide__slide.is-active"));
+        }
+    });
+}
+
 function ensureSplideLoaded() {
     return new Promise((resolve, reject) => {
         if (window.Splide) return resolve();
@@ -378,6 +461,7 @@ function renderHeroSlide(item, data, baseUrl) {
     const rating = buildRating(item);
     const logoOrTitle = buildLogoOrTitle(item, data.reduceImageSizes);
     const overview = buildOverview(item);
+    const trailer = buildBackgroundTrailer(item, data);
 
     let button = "";
 
@@ -403,6 +487,7 @@ function renderHeroSlide(item, data, baseUrl) {
      onclick="Emby.Page.showItem('${item.id}'); return false;"
      class="editorsChoiceItemBanner splide__slide">
     <div class="editorsChoiceBackdrop ${extraClass}" style="background-image:url('${backdropUrl}');"></div>
+    ${trailer}
     <div class="editorsChoiceContent">
       ${logoOrTitle}
       ${rating}
@@ -416,6 +501,7 @@ function renderNormalSlide(item, data, baseUrl) {
     const rating = buildRating(item);
     const logoOrTitle = buildLogoOrTitle(item, data.reduceImageSizes);
     const overview = buildOverview(item);
+    const trailer = buildBackgroundTrailer(item, data);
 
     const bannerSize = buildBannerSizeParam(data.reduceImageSizes);
     let button = "";
@@ -434,6 +520,7 @@ function renderNormalSlide(item, data, baseUrl) {
                  onclick="Emby.Page.showItem('${item.id}'); return false;"
                  class="editorsChoiceItemBanner splide__slide"
                  style="background-image:url('../Items/${item.id}/Images/Backdrop/0${bannerSize}');">
+                ${trailer}
                 <div>
                   ${logoOrTitle}
                   ${rating}
@@ -549,7 +636,7 @@ async function setup() {
                 const playPauseBtn = containerElem.querySelector(".editorsChoicePlayPause");
                 if (playPauseBtn) playPauseBtn.style.display = data.autoplay ? "" : "none";
 
-                new Splide(containerElem.querySelector(".splide"), {
+                const splide = new Splide(containerElem.querySelector(".splide"), {
                     type: data.transitionEffect ?? "loop",
                     autoplay: !!data.autoplay,
                     rewind: true,
@@ -557,7 +644,9 @@ async function setup() {
                     pagination: false,
                     keyboard: true,
                     height: `${data.bannerHeight + (data.useHeroLayout ? 180 : 0)}px`, // Add 80px to the banner image height in hero mode to compensate for navbar overlay
-                }).mount();
+                });
+                configureBackgroundTrailers(splide, containerElem);
+                splide.mount();
 
                 initializedContainers.add(elem);
                 elem.classList.add(EDITORS_CHOICE_ADDED_CLASS);

--- a/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
+++ b/EditorsChoicePlugin/Configuration/PluginConfiguration.cs
@@ -31,6 +31,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool EnableAutoplay { get; set; } = true;
 
+    public bool EnableBackgroundTrailers { get; set; } = false;
+
     public int AutoplayInterval { get; set; } = 10;
 
     public bool ShowPlayButton { get; set; } = true;

--- a/EditorsChoicePlugin/Configuration/configPage.html
+++ b/EditorsChoicePlugin/Configuration/configPage.html
@@ -254,6 +254,14 @@
                         <div class="fieldDescription">How often, in seconds, the slider moves to the next item. Default is 10 seconds.</div>
                     </div>
 
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input is="emby-checkbox" type="checkbox" id="EnableBackgroundTrailers" name="EnableBackgroundTrailers" />
+                            <span class="checkboxLabel">Play local trailers in the background</span>
+                        </label>
+                        <div class="fieldDescription">When a slide is active, play its local Jellyfin trailer muted behind the item details. Remote trailers are not loaded.</div>
+                    </div>
+
                     <hr />
                     <h2>Filtering</h2>
 
@@ -437,6 +445,7 @@
                         $('#MinimumRating').val(config.MinimumRating);
                         $('#MinimumCriticRating').val(config.MinimumCriticRating);
                         $('#EnableAutoplay').first().prop('checked', config.EnableAutoplay);
+                        $('#EnableBackgroundTrailers').first().prop('checked', config.EnableBackgroundTrailers);
                         $('#AutoplayInterval').first().val(config.AutoplayInterval);
                         $("#NewTimeLimitSelect").val(config.NewTimeLimit);
                         $('#ShowRating').first().prop('checked', config.ShowRating);
@@ -579,6 +588,7 @@
                         config.DoScriptInject = $('#DoScriptInject').first().is(':checked');
                         config.FileTransformation = $('#FileTransformation').first().is(':checked');
                         config.EnableAutoplay = $('#EnableAutoplay').first().is(':checked');
+                        config.EnableBackgroundTrailers = $('#EnableBackgroundTrailers').first().is(':checked');
                         config.AutoplayInterval = $('#AutoplayInterval').first().val();
                         config.ShowRating = $('#ShowRating').first().is(':checked');
                         config.ShowDescription =  $('#ShowDesc').first().is(':checked');

--- a/EditorsChoicePlugin/EditorsChoicePlugin.csproj
+++ b/EditorsChoicePlugin/EditorsChoicePlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,9 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Common" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Common" Version="12.0.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add an opt-in setting for muted local trailer playback behind the active slide
- expose only the first local trailer that is visible to the requesting user
- lazy-load trailer video after a slide remains active for 1.5 seconds
- pause and reset video when the slide or browser tab becomes inactive
- respect reduced-motion and data-saver preferences
- keep remote trailer URLs disabled to avoid third-party requests and embedding concerns

## Security
Trailer IDs are added only after both the parent item and local trailer pass active-user visibility checks. Playback uses Jellyfin's authenticated same-origin video endpoint; the plugin does not proxy files or expose filesystem paths.

## Testing
- Release build succeeds with 0 warnings and 0 errors
- client script passes Node syntax validation

## Dependency
- based on and depends on #82 for Jellyfin 12 support

Closes #69